### PR TITLE
Assign prefix for XML Schema

### DIFF
--- a/examples/call_log.json
+++ b/examples/call_log.json
@@ -4,7 +4,8 @@
         "kb": "http://example.org/kb/",
         "draft": "http://example.org/draft#",
         "uco-core": "https://unifiedcyberontology.org/ontology/uco/core#",
-        "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#"
+        "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {

--- a/examples/device.json
+++ b/examples/device.json
@@ -6,7 +6,8 @@
         "draft": "http://example.org/draft#",
         "olo": "http://purl.org/ontology/olo/core#",
         "uco-core": "https://unifiedcyberontology.org/ontology/uco/core#",
-        "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#"
+        "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {

--- a/examples/forensic_lifecycle.json
+++ b/examples/forensic_lifecycle.json
@@ -10,7 +10,8 @@
         "uco-types": "https://unifiedcyberontology.org/ontology/uco/types#",
         "uco-vocabulary": "https://unifiedcyberontology.org/ontology/uco/vocabulary#",
         "draft": "http://example.org/draft#",
-        "olo": "http://purl.org/ontology/olo/core#"
+        "olo": "http://purl.org/ontology/olo/core#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {

--- a/examples/location.json
+++ b/examples/location.json
@@ -6,7 +6,8 @@
         "draft": "http://example.org/draft#",
         "olo": "http://purl.org/ontology/olo/core#",
         "uco-core": "https://unifiedcyberontology.org/ontology/uco/core#",
-        "uco-location": "https://unifiedcyberontology.org/ontology/uco/location#"
+        "uco-location": "https://unifiedcyberontology.org/ontology/uco/location#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {

--- a/examples/message.json
+++ b/examples/message.json
@@ -5,7 +5,8 @@
         "draft": "http://example.org/draft#",
         "olo": "http://purl.org/ontology/olo/core#",
         "uco-core": "https://unifiedcyberontology.org/ontology/uco/core#",
-        "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#"
+        "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {

--- a/examples/mobile_device_and_sim_card.json
+++ b/examples/mobile_device_and_sim_card.json
@@ -7,7 +7,8 @@
         "olo": "http://purl.org/ontology/olo/core#",
         "uco-core": "https://unifiedcyberontology.org/ontology/uco/core#",
         "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
-        "uco-vocabulary": "https://unifiedcyberontology.org/ontology/uco/vocabulary#"
+        "uco-vocabulary": "https://unifiedcyberontology.org/ontology/uco/vocabulary#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {

--- a/examples/sms_and_contacts.json
+++ b/examples/sms_and_contacts.json
@@ -6,7 +6,8 @@
         "olo": "http://purl.org/ontology/olo/core#",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
         "uco-core": "https://unifiedcyberontology.org/ontology/uco/core#",
-        "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#"
+        "uco-observable": "https://unifiedcyberontology.org/ontology/uco/observable#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#"
     },
     "@graph": [
         {


### PR DESCRIPTION
The XML Schema datatypes prefix is "xs:" in some RDF frameworks, "xsd:"
in others.  If not specified, a framework may assume the default-looking
prefix it doesn't use is an arbitrary string.

(This commit mirrors another commit for the website.)

References:
* [AC-154] XML Schema datatype prefix needs to be explicit in all
  examples

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>