### PR TITLE
Use Python venv to build virtual environment for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Python virtualenv for Github runner
-      run: |
-        python -m pip install --upgrade pip
-        pip install virtualenv
     - name: Start from clean state
       run: make clean
     - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ all: \
 .venv.done.log: \
   .git_submodule_init.done.log
 	rm -rf venv
-	$(PYTHON3) -m virtualenv \
-	  --python=$(PYTHON3) \
+	$(PYTHON3) -m venv \
 	  venv
 	source venv/bin/activate \
 	  && pip install \


### PR DESCRIPTION
References:
* [AC-195] Use Python venv instead of virtualenv to build virtual
  environments for CI

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>