### PR TITLE
Fix call type to comply with standard

### DIFF
--- a/examples/illustrations/call_log/call_log.json
+++ b/examples/illustrations/call_log/call_log.json
@@ -48,7 +48,7 @@
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:PhoneCallFacet",
-                    "uco-observable:callType": "mobile",
+                    "uco-observable:callType": "outgoing",
                     "uco-observable:startTime": {
                         "@type": "xsd:dateTime",
                         "@value": "2010-01-15T17:59:43.25Z"


### PR DESCRIPTION
Per ONT-279 and https://github.com/ucoProject/UCO/blob/master/uco-observable/observable.ttl#L8482, this call type example should be the call disposition and not the device type.