### PR TITLE
Add sentTime attribute to message

### DIFF
--- a/examples/illustrations/message/message.json
+++ b/examples/illustrations/message/message.json
@@ -192,7 +192,11 @@
                         {
                             "@id": "kb:account4"
                         }
-                    ]
+                    ],
+                    "uco-observable:sentTime": {
+                        "@type": "xsd:dateTime",
+                        "@value": "2010-01-16T16:34:56.25Z"
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Addresses AC-142 by adding the uco-observable:sentTime attribute to the other uco-observable:MessageFacet that is present in the message.json example file.