### PR TITLE
Build validation status of illustrations with case_utils 0.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: '8'
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ all: \
 	  || (git submodule init dependencies/CASE-0.3.0/CASE && git submodule update dependencies/CASE-0.3.0/CASE)
 	@test -r dependencies/CASE-0.3.0/CASE/README.md \
 	  || (echo "ERROR:Makefile:CASE-0.3.0 CASE submodule README.md file not found, even though CASE submodule initialized." >&2 ; exit 2)
+	# Retrieve rdf-toolkit.jar.
+	$(MAKE) \
+	  --directory dependencies/CASE-0.3.0/CASE \
+	  .lib.done.log
 	# UCO (CASE 0.4.0)
 	test -r dependencies/CASE-0.4.0/UCO/README.md \
 	  || (git submodule init dependencies/CASE-0.4.0/UCO && git submodule update dependencies/CASE-0.4.0/UCO)

--- a/examples/illustrations/Makefile
+++ b/examples/illustrations/Makefile
@@ -14,13 +14,29 @@
 SHELL := /bin/bash
 
 .PHONY: \
+  all-exif_data \
+  all-location \
+  all-message \
   check-exif_data \
   check-location \
   check-message
 
-all:
+all: \
+  all-exif_data \
+  all-location \
+  all-message
+
+all-exif_data:
 	$(MAKE) \
 	  --directory exif_data
+
+all-location:
+	$(MAKE) \
+	  --directory location
+
+all-message:
+	$(MAKE) \
+	  --directory message
 
 check: \
   check-exif_data \
@@ -45,4 +61,10 @@ check-message:
 clean:
 	@$(MAKE) \
 	  --directory exif_data \
+	  clean
+	@$(MAKE) \
+	  --directory location \
+	  clean
+	@$(MAKE) \
+	  --directory message \
 	  clean

--- a/examples/illustrations/Makefile
+++ b/examples/illustrations/Makefile
@@ -14,9 +14,22 @@
 SHELL := /bin/bash
 
 illustration_dirs := \
+  Oresteia \
+  accounts \
+  bulk_extractor_forensic_path \
+  call_log \
+  device \
   exif_data \
+  file \
+  forensic_lifecycle \
   location \
-  message
+  message \
+  mobile_device_and_sim_card \
+  multipart_file \
+  network_connection \
+  raw_data \
+  reconstructed_file \
+  sms_and_contacts
 
 all_targets := $(foreach illustration_dir,$(illustration_dirs),all-$(illustration_dir))
 

--- a/examples/illustrations/Makefile
+++ b/examples/illustrations/Makefile
@@ -13,58 +13,44 @@
 
 SHELL := /bin/bash
 
-.PHONY: \
-  all-exif_data \
-  all-location \
-  all-message \
-  check-exif_data \
-  check-location \
-  check-message
+illustration_dirs := \
+  exif_data \
+  location \
+  message
+
+all_targets := $(foreach illustration_dir,$(illustration_dirs),all-$(illustration_dir))
+
+check_targets := $(foreach illustration_dir,$(illustration_dirs),check-$(illustration_dir))
+
+clean_targets := $(foreach illustration_dir,$(illustration_dirs),clean-$(illustration_dir))
 
 all: \
-  all-exif_data \
-  all-location \
-  all-message
+  $(all_targets)
 
-all-exif_data:
-	$(MAKE) \
-	  --directory exif_data
+.PHONY: \
+  all-% \
+  check-% \
+  clean-%
 
-all-location:
-	$(MAKE) \
-	  --directory location
-
-all-message:
-	$(MAKE) \
-	  --directory message
+all-%:
+	export x=$@ \
+	  && $(MAKE) \
+	    --directory $${x/all-}
 
 check: \
-  check-exif_data \
-  check-location \
-  check-message
+  $(check_targets)
 
-check-exif_data:
-	$(MAKE) \
-	  --directory exif_data \
-	  check
+check-%:
+	export x=$@ \
+	  && $(MAKE) \
+	    --directory $${x/check-} \
+	    check
 
-check-location:
-	$(MAKE) \
-	  --directory location \
-	  check
+clean: \
+  $(clean_targets)
 
-check-message:
-	$(MAKE) \
-	  --directory message \
-	  check
-
-clean:
-	@$(MAKE) \
-	  --directory exif_data \
-	  clean
-	@$(MAKE) \
-	  --directory location \
-	  clean
-	@$(MAKE) \
-	  --directory message \
-	  clean
+clean-%:
+	@export x=$@ \
+	  && $(MAKE) \
+	    --directory $${x/clean-} \
+	    clean

--- a/examples/illustrations/Oresteia/Makefile
+++ b/examples/illustrations/Oresteia/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/Oresteia/Oresteia_validation.ttl
+++ b/examples/illustrations/Oresteia/Oresteia_validation.ttl
@@ -1,0 +1,1165 @@
+@prefix action: <https://unifiedcyberontology.org/ontology/uco/action#> .
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix investigation: <https://ontology.caseontology.org/case/investigation/> .
+@prefix location: <https://unifiedcyberontology.org/ontology/uco/location#> .
+@prefix ns1: <http://example.org/draft#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vocab: <https://ontology.caseontology.org/case/vocabulary/> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/aeschylus-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/eoghan-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/annotation3-uuid> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/orestes-selfie-photograph-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/attach_relationship1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:source ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:source ;
+			] ;
+			sh:value <http://example.org/kb/location1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/bundle-3b13e958a-d975-41aa-b1bb-029d2b6707cd> ;
+			sh:resultMessage "More than 1 values on kb:bundle-3b13e958a-d975-41aa-b1bb-029d2b6707cd->core:description" ;
+			sh:resultPath core:description ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:description ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/clytemnestra-device-uuid> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a ns1:iPhoneDevice ;
+				ns1:ownerName "Clytemnestras iPhone" ;
+				ns1:uniqueID "B3858A69A29375E6C706226B3633A3A11EB2A774" ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/euripides-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/eoghan-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-2545442b-321c-754d-bcb8-c40d321ce2c2> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-2545442b-321c-754d-bcb8-c40d321ce2c2->core:object" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-2545442b-321c-754d-bcb8-c40d321ce2c2> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-2545442b-321c-754d-bcb8-c40d321ce2c2->investigation:investigationForm" ;
+			sh:resultPath investigation:investigationForm ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocab:InvestigationFormVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path investigation:investigationForm ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-4586742a-710a-454f-bcb8-b60e230ec1b2> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-4586742a-710a-454f-bcb8-b60e230ec1b2->investigation:investigationForm" ;
+			sh:resultPath investigation:investigationForm ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocab:InvestigationFormVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path investigation:investigationForm ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-5aa33dc6-7a39-4731-a754-62a9c41e5220> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-5aa33dc6-7a39-4731-a754-62a9c41e5220->investigation:investigationForm" ;
+			sh:resultPath investigation:investigationForm ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocab:InvestigationFormVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path investigation:investigationForm ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-952d677d-6b62-4e53-9bac-1b113d268ac5> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-952d677d-6b62-4e53-9bac-1b113d268ac5->investigation:investigationForm" ;
+			sh:resultPath investigation:investigationForm ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocab:InvestigationFormVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path investigation:investigationForm ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-952d677d-6b62-4e53-9bac-1b113d268ac5> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a investigation:Authorization ;
+				investigation:authorizationIdentifier "Warrant12345" ;
+				investigation:authorizationType "warrant" ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-ac9fd560-261e-4cd6-af64-8b83d100b9a8> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-ac9fd560-261e-4cd6-af64-8b83d100b9a8->core:object" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-ac9fd560-261e-4cd6-af64-8b83d100b9a8> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-ac9fd560-261e-4cd6-af64-8b83d100b9a8->investigation:investigationForm" ;
+			sh:resultPath investigation:investigationForm ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocab:InvestigationFormVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path investigation:investigationForm ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-b05226da-eaef-4bc5-a139-ca12c94dbdfd> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-b05226da-eaef-4bc5-a139-ca12c94dbdfd->investigation:investigationForm" ;
+			sh:resultPath investigation:investigationForm ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocab:InvestigationFormVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path investigation:investigationForm ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-b05226da-eaef-4bc5-a139-ca12c94dbdfd> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/cctv-recording-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigative-action2-uuid> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a <mobileextractor:ToolArguments> ;
+				ns1:aquisitionType "Physical Extraction" ;
+				ns1:method "Boot Loader" ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigator1-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/eoghan-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigator2-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/eoghan-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/orestes-facebookmsg-uuid> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a ns1:FacebookMessage ;
+				observable:body "There lies our country's twofold tyranny, My father's slayers, spoilers of my home." ;
+				observable:from <http://example.org/kb/orestes-facebookaccount-uuid> ;
+				observable:sentTime "2017-06-21T14:44:54.190000+00:00"^^xsd:dateTime ;
+				observable:to <http://example.org/kb/friends> ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/role-relationship51-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/eoghan-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/role-relationship52-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/eoghan-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship3-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship4-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MobileDeviceFacet ;
+				rdfs:comment
+					"TODO: MSISDN here may be the wrong type.  Why is a uuid indicated?" ,
+					"TODO: Should clockSetting be a xsd:dateTime?" ,
+					"TODO: clockSetting as a time-point somewhat illustrates the scenario's specified skew of 25 hours, but might need a reference time-point."
+					;
+				ns1:localeLanguage "en_GR" ;
+				observable:IMEI "359305065690067" ;
+				observable:MSISDN <http://example.org/kb/clytemnestra-mobileaccount-uuid> ;
+				observable:clockSetting "2017-06-21T06:36:24.350000+00:00"^^xsd:dateTime ;
+				observable:keypadUnlockCode "123789" ;
+				observable:phoneActivationTime "2017-05-09T07:36:24.350000+00:00"^^xsd:dateTime ;
+				observable:storageCapacityInBytes "11000000000"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath observable:MSISDN ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:MSISDN ;
+			] ;
+			sh:value <http://example.org/kb/clytemnestra-mobileaccount-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MobileDeviceFacet ;
+				rdfs:comment
+					"TODO: MSISDN here may be the wrong type.  Why is a uuid indicated?" ,
+					"TODO: Should clockSetting be a xsd:dateTime?" ,
+					"TODO: clockSetting as a time-point somewhat illustrates the scenario's specified skew of 25 hours, but might need a reference time-point."
+					;
+				ns1:localeLanguage "en_GR" ;
+				observable:IMEI "359305065690067" ;
+				observable:MSISDN <http://example.org/kb/clytemnestra-mobileaccount-uuid> ;
+				observable:clockSetting "2017-06-21T06:36:24.350000+00:00"^^xsd:dateTime ;
+				observable:keypadUnlockCode "123789" ;
+				observable:phoneActivationTime "2017-05-09T07:36:24.350000+00:00"^^xsd:dateTime ;
+				observable:storageCapacityInBytes "11000000000"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not of Node Kind sh:Literal" ;
+			sh:resultPath observable:MSISDN ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:MSISDN ;
+			] ;
+			sh:value <http://example.org/kb/clytemnestra-mobileaccount-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic-computer1-uuid> ;
+				action:instrument <http://example.org/kb/tool1-uuid> ;
+				action:location <http://example.org/kb/argos-palace-uuid> ;
+				action:object
+					<http://example.org/kb/cassandra-device-uuid> ,
+					<http://example.org/kb/provenance-record2-uuid>
+					;
+				action:performer <http://example.org/kb/investigator1-uuid> ;
+				action:result
+					<http://example.org/kb/cassandra-mobiledevice-forensicduplicate-uuid> ,
+					<http://example.org/kb/provenance-record3-uuid>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic-computer1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic-computer1-uuid> ;
+				action:instrument <http://example.org/kb/tool2-uuid> ;
+				action:location <http://example.org/kb/argos-palace-uuid> ;
+				action:object
+					<http://example.org/kb/cassandra-mobiledevice-forensicduplicate-uuid> ,
+					<http://example.org/kb/provenance-record3-uuid>
+					;
+				action:performer <http://example.org/kb/investigator1-uuid> ;
+				action:result
+					<http://example.org/kb/cassandra-mobiledevice-mmssms-uuid> ,
+					<http://example.org/kb/investigative-action5-uuid> ,
+					<http://example.org/kb/provenance-record4-uuid>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic-computer1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic-computer1-uuid> ;
+				action:instrument <http://example.org/kb/tool3-uuid> ;
+				action:location <http://example.org/kb/argos-palace-uuid> ;
+				action:object
+					<http://example.org/kb/cassandra-mobiledevice-mmssms-uuid> ,
+					<http://example.org/kb/provenance-record4-uuid>
+					;
+				action:performer <http://example.org/kb/investigative-action4-uuid> ;
+				action:result
+					<http://example.org/kb/argive-elder1-phoneaccnt-uuid> ,
+					<http://example.org/kb/argive-elder2-phoneaccnt-uuid> ,
+					<http://example.org/kb/argive-elder3-phoneaccnt-uuid> ,
+					<http://example.org/kb/provenance-record5-uuid> ,
+					<http://example.org/kb/sms-message1-uuid> ,
+					<http://example.org/kb/sms-message2-uuid>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic-computer1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:instrument <http://example.org/kb/athens-warrant1-uuid> ;
+				action:location <http://example.org/kb/argos-palace-uuid> ;
+				action:performer <http://example.org/kb/investigator2-uuid> ;
+				action:result
+					<http://example.org/kb/cassandra-device-uuid> ,
+					<http://example.org/kb/provenance-record1-uuid>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/athens-warrant1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:instrument <http://example.org/kb/athens-warrant1-uuid> ;
+				action:location <http://example.org/kb/athenspd-evidenceroom-uuid> ;
+				action:object
+					<http://example.org/kb/cassandra-device-uuid> ,
+					<http://example.org/kb/provenance-record1-uuid>
+					;
+				action:performer <http://example.org/kb/investigator1-uuid> ;
+				action:result <http://example.org/kb/provenance-record2-uuid> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/athens-warrant1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:instrument <http://example.org/kb/athens-warrant1-uuid> ;
+				action:location <http://example.org/kb/athenspd-evidenceroom-uuid> ;
+				action:object
+					<http://example.org/kb/cassandra-device-uuid> ,
+					<http://example.org/kb/provenance-record1-uuid>
+					;
+				action:performer <http://example.org/kb/investigator1-uuid> ;
+				action:result <http://example.org/kb/provenance-record2-uuid> ;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/athenspd-evidenceroom-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a core:ConfidenceFacet ;
+				rdfs:comment "TODO This no longer matches the type prescription in UCO." ;
+				core:confidence "Probably True" ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:nonNegativeInteger" ;
+			sh:resultPath core:confidence ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:nonNegativeInteger ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:confidence ;
+			] ;
+			sh:value "Probably True" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a core:ConfidenceFacet ;
+				rdfs:comment "TODO This no longer matches the type prescription in UCO." ;
+				core:confidence "Probably True" ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:nonNegativeInteger" ;
+			sh:resultPath core:confidence ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:nonNegativeInteger ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:confidence ;
+			] ;
+			sh:value "Probably True" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a location:LatLongCoordinatesFacet ;
+				location:latitude "4.886035e+01"^^xsd:double ;
+				location:longitude "2.331199e+00"^^xsd:double ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:decimal" ;
+			sh:resultPath location:latitude ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:decimal ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path location:latitude ;
+			] ;
+			sh:value "4.886035e+01"^^xsd:double ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a location:LatLongCoordinatesFacet ;
+				location:latitude "4.886035e+01"^^xsd:double ;
+				location:longitude "2.331199e+00"^^xsd:double ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:decimal" ;
+			sh:resultPath location:longitude ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:decimal ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path location:longitude ;
+			] ;
+			sh:value "2.331199e+00"^^xsd:double ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/olympus-uuid> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:olympus-uuid ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/olympus-uuid> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath observable:accountIssuer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:accountIssuer ;
+			] ;
+			sh:value <http://example.org/kb/olympus-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/olympus-uuid> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:olympus-uuid ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/olympus-uuid> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath observable:accountIssuer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:accountIssuer ;
+			] ;
+			sh:value <http://example.org/kb/olympus-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/olympus-uuid> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:olympus-uuid ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/olympus-uuid> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath observable:accountIssuer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:accountIssuer ;
+			] ;
+			sh:value <http://example.org/kb/olympus-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "PhoneAccount" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountType Literal("PhoneAccount") ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "PhoneAccount" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:AccountTypeVocab" ;
+			sh:resultPath observable:accountType ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:AccountTypeVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountType ;
+			] ;
+			sh:value "PhoneAccount" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "PhoneAccount" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountType Literal("PhoneAccount") ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "PhoneAccount" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:AccountTypeVocab" ;
+			sh:resultPath observable:accountType ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:AccountTypeVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountType ;
+			] ;
+			sh:value "PhoneAccount" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AttachmentFacet ;
+				rdfs:comment "TODO: uco-observable:Attachment seems ill-defined." ;
+				observable:url "http://www.facebook.com/corpses.jpg" ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:url ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:url ;
+			] ;
+			sh:value "http://www.facebook.com/corpses.jpg" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AttachmentFacet ;
+				rdfs:comment "TODO: uco-observable:Attachment seems ill-defined." ;
+				observable:url "http://www.facebook.com/corpses.jpg" ;
+			] ;
+			sh:resultMessage "Value is not of Node Kind sh:BlankNodeOrIRI" ;
+			sh:resultPath observable:url ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:url ;
+			] ;
+			sh:value "http://www.facebook.com/corpses.jpg" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:BluetoothAddressFacet ;
+				observable:value "d0:33:11:13:e7:a2" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:BluetoothAddressFacet ; uco-observable:value Literal("d0:33:11:13:e7:a2") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:BluetoothAddressFacet ;
+				observable:value "d0:33:11:13:e7:a2" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:BluetoothAddressFacet ; uco-observable:value Literal("d0:33:11:13:e7:a2") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:BluetoothAddressFacet ;
+				observable:value "d0:33:11:13:e7:a2" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:BluetoothAddressFacet ; uco-observable:value Literal("d0:33:11:13:e7:a2") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:EmailAccountFacet ;
+				observable:emailAddress "electra.pleiade@sevensisters.com" ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:emailAddress ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:emailAddress ;
+			] ;
+			sh:value "electra.pleiade@sevensisters.com" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:EmailAccountFacet ;
+				observable:emailAddress "electra.pleiade@sevensisters.com" ;
+			] ;
+			sh:resultMessage "Value is not of Node Kind sh:BlankNodeOrIRI" ;
+			sh:resultPath observable:emailAddress ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:emailAddress ;
+			] ;
+			sh:value "electra.pleiade@sevensisters.com" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:EmailMessageFacet ;
+				observable:body "To me, too, grant this boon-dark death to deal unto Aegisthus, and to 'scape my doom." ;
+				observable:from <http://example.org/kb/electra-emailaccount-uuid> ;
+				observable:messageID "CAKBqNfyKo+ZXtkz6DUjWpvHy6O82jTbkNA@mail.gmail.com" ;
+				observable:receivedTime "2017-06-21T13:44:23.400000+00:00"^^xsd:dateTime ;
+				observable:sentTime "2017-06-21T13:44:22.190000+00:00"^^xsd:dateTime ;
+				observable:subject "Revenge our father" ;
+				observable:to <http://example.org/kb/orestes-emailaccount-uuid> ;
+			] ;
+			sh:resultMessage "Less than 1 values on [ rdf:type uco-observable:EmailMessageFacet ; uco-observable:body Literal(\"To me, too, grant this boon-dark death to deal unto Aegisthus, and to 'scape my doom.\") ; uco-observable:from kb:electra-emailaccount-uuid ; uco-observable:messageID Literal(\"CAKBqNfyKo+ZXtkz6DUjWpvHy6O82jTbkNA@mail.gmail.com\") ; uco-observable:receivedTime Literal(\"2017-06-21T13:44:23.400000+00:00\" = 2017-06-21 13:44:23.400000+00:00, datatype=xsd:dateTime) ; uco-observable:sentTime Literal(\"2017-06-21T13:44:22.190000+00:00\" = 2017-06-21 13:44:22.190000+00:00, datatype=xsd:dateTime) ; uco-observable:subject Literal(\"Revenge our father\") ; uco-observable:to kb:orestes-emailaccount-uuid ]->observable:isMimeEncoded" ;
+			sh:resultPath observable:isMimeEncoded ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:boolean ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:isMimeEncoded ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:EmailMessageFacet ;
+				observable:body "To me, too, grant this boon-dark death to deal unto Aegisthus, and to 'scape my doom." ;
+				observable:from <http://example.org/kb/electra-emailaccount-uuid> ;
+				observable:messageID "CAKBqNfyKo+ZXtkz6DUjWpvHy6O82jTbkNA@mail.gmail.com" ;
+				observable:receivedTime "2017-06-21T13:44:23.400000+00:00"^^xsd:dateTime ;
+				observable:sentTime "2017-06-21T13:44:22.190000+00:00"^^xsd:dateTime ;
+				observable:subject "Revenge our father" ;
+				observable:to <http://example.org/kb/orestes-emailaccount-uuid> ;
+			] ;
+			sh:resultMessage "Less than 1 values on [ rdf:type uco-observable:EmailMessageFacet ; uco-observable:body Literal(\"To me, too, grant this boon-dark death to deal unto Aegisthus, and to 'scape my doom.\") ; uco-observable:from kb:electra-emailaccount-uuid ; uco-observable:messageID Literal(\"CAKBqNfyKo+ZXtkz6DUjWpvHy6O82jTbkNA@mail.gmail.com\") ; uco-observable:receivedTime Literal(\"2017-06-21T13:44:23.400000+00:00\" = 2017-06-21 13:44:23.400000+00:00, datatype=xsd:dateTime) ; uco-observable:sentTime Literal(\"2017-06-21T13:44:22.190000+00:00\" = 2017-06-21 13:44:22.190000+00:00, datatype=xsd:dateTime) ; uco-observable:subject Literal(\"Revenge our father\") ; uco-observable:to kb:orestes-emailaccount-uuid ]->observable:isMultipart" ;
+			sh:resultPath observable:isMultipart ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:boolean ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:isMultipart ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MessageFacet ;
+				rdfs:comment
+					"TODO: uco-observable:sentTime only has a domain of uco-observable:EmailMessage." ,
+					"TODO: uco-observable:to only has a domain of uco-observable:PhoneCall."
+					;
+				observable:application <http://example.org/kb/sms-application1> ;
+				observable:from <http://example.org/kb/cassandra-mobileaccount-uuid> ;
+				observable:messageText "A wedded wife, she slays her lord, Helped by another hand!" ;
+				observable:sentTime "2017-06-20T09:34:42.120000+00:00"^^xsd:dateTime ;
+				observable:to
+					<http://example.org/kb/argive-elder1-phoneaccnt-uuid> ,
+					<http://example.org/kb/argive-elder2-phoneaccnt-uuid> ,
+					<http://example.org/kb/argive-elder3-phoneaccnt-uuid>
+					;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+			sh:value <http://example.org/kb/sms-application1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MessageFacet ;
+				observable:application <http://example.org/kb/sms-application1> ;
+				observable:from <http://example.org/kb/cassandra-mobileaccount-uuid> ;
+				observable:messageText "Low lie the shattered towers whereas they fell, and I--ah burning heart!--shall soon lie low as well." ;
+				observable:sentTime "2017-06-20T09:37:35.130000+00:00"^^xsd:dateTime ;
+				observable:to
+					<http://example.org/kb/argive-elder1-phoneaccnt-uuid> ,
+					<http://example.org/kb/argive-elder2-phoneaccnt-uuid> ,
+					<http://example.org/kb/argive-elder3-phoneaccnt-uuid>
+					;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+			sh:value <http://example.org/kb/sms-application1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:WifiAddressFacet ;
+				observable:value "d0:33:11:13:e7:a1" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:WifiAddressFacet ; uco-observable:value Literal("d0:33:11:13:e7:a1") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:WifiAddressFacet ;
+				observable:value "d0:33:11:13:e7:a1" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:WifiAddressFacet ; uco-observable:value Literal("d0:33:11:13:e7:a1") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:WifiAddressFacet ;
+				observable:value "d0:33:11:13:e7:a1" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:WifiAddressFacet ; uco-observable:value Literal("d0:33:11:13:e7:a1") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		]
+		;
+	.
+

--- a/examples/illustrations/accounts/Makefile
+++ b/examples/illustrations/accounts/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/accounts/accounts_validation.ttl
+++ b/examples/illustrations/accounts/accounts_validation.ttl
@@ -1,0 +1,147 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIdentifier "1235556677@facebook.net" ;
+				observable:accountIssuer <http://example.org/kb/facebook_org> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath observable:accountIssuer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:accountIssuer ;
+			] ;
+			sh:value <http://example.org/kb/facebook_org> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIdentifier "willyROX@gmail.com" ;
+				observable:accountIssuer <http://example.org/kb/google_org> ;
+				observable:observableCreatedTime "2010-01-15T17:59:43.250000+00:00"^^xsd:dateTime ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath observable:accountIssuer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:accountIssuer ;
+			] ;
+			sh:value <http://example.org/kb/google_org> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ApplicationAccountFacet ;
+				observable:application <http://example.org/kb/application1> ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+			sh:value <http://example.org/kb/application1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ApplicationAccountFacet ;
+				observable:application <http://example.org/kb/application2> ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+			sh:value <http://example.org/kb/application2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:EmailAccountFacet ;
+				observable:emailAddress <http://example.org/kb/email-address1> ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:emailAddress ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:emailAddress ;
+			] ;
+			sh:value <http://example.org/kb/email-address1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:EmailAddressFacet ;
+				observable:value "willyROX@gmail.com" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:EmailAddressFacet ; uco-observable:value Literal("willyROX@gmail.com") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:EmailAddressFacet ;
+				observable:value "willyROX@gmail.com" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:EmailAddressFacet ; uco-observable:value Literal("willyROX@gmail.com") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		]
+		;
+	.
+

--- a/examples/illustrations/bulk_extractor_forensic_path/Makefile
+++ b/examples/illustrations/bulk_extractor_forensic_path/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/bulk_extractor_forensic_path/bulk_extractor_forensic_path_validation.ttl
+++ b/examples/illustrations/bulk_extractor_forensic_path/bulk_extractor_forensic_path_validation.ttl
@@ -1,0 +1,216 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix types: <https://unifiedcyberontology.org/ontology/uco/types#> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship0> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship1> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship4> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship6> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "SHA256"^^core:HashNameEnum ;
+				types:hashValue "03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4"^^xsd:hexBinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:HashNameVocab" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:HashNameVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "SHA256"^^core:HashNameEnum ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "SHA256"^^core:HashNameEnum ;
+				types:hashValue "5994471abb01112afcc18159f6cc74b4f511b99806da59b3caf5a9c173cacfc5"^^xsd:hexBinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:HashNameVocab" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:HashNameVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "SHA256"^^core:HashNameEnum ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "SHA256"^^core:HashNameEnum ;
+				types:hashValue "8c8b39473c4064f6b4db11a67251ffdf65c42ebadc5c3e02a009f95f6cf7c9e8"^^xsd:hexBinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:HashNameVocab" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:HashNameVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "SHA256"^^core:HashNameEnum ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "SHA256"^^core:HashNameEnum ;
+				types:hashValue "8d969eef6ecad3c29a3a629280e686cf0c3f5d5a86aff3ca12020c923adc6c92"^^xsd:hexBinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:HashNameVocab" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:HashNameVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "SHA256"^^core:HashNameEnum ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "SHA256"^^core:HashNameEnum ;
+				types:hashValue "8fabebdaf41b54014f6c3507c44ae160547d05d31bd50d6a12234c5bc4bdb45c"^^xsd:hexBinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:HashNameVocab" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:HashNameVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "SHA256"^^core:HashNameEnum ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "SHA256"^^core:HashNameEnum ;
+				types:hashValue "9a6c11d66829bf429efe5ef4c066d50272394481cc3f8ae8116a006c81dc6cf9"^^xsd:hexBinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:HashNameVocab" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:HashNameVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "SHA256"^^core:HashNameEnum ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "SHA256"^^core:HashNameEnum ;
+				types:hashValue "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"^^xsd:hexBinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:HashNameVocab" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:HashNameVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "SHA256"^^core:HashNameEnum ;
+		]
+		;
+	.
+

--- a/examples/illustrations/call_log/Makefile
+++ b/examples/illustrations/call_log/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/call_log/call_log_validation.ttl
+++ b/examples/illustrations/call_log/call_log_validation.ttl
@@ -1,0 +1,133 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix ns1: <http://example.org/local#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:PhoneAccountFacet ;
+				ns1:identifier "1234560000" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ :identifier Literal("1234560000") ; rdf:type uco-observable:PhoneAccountFacet ]->observable:phoneNumber' ;
+			sh:resultPath observable:phoneNumber ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:phoneNumber ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/ATT> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:ATT ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/ATT> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath observable:accountIssuer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:accountIssuer ;
+			] ;
+			sh:value <http://example.org/kb/ATT> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/Sprint> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Sprint ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountIssuer <http://example.org/kb/Sprint> ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath observable:accountIssuer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:accountIssuer ;
+			] ;
+			sh:value <http://example.org/kb/Sprint> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:PhoneCallFacet ;
+				observable:callType "outgoing" ;
+				observable:duration "1862"^^xsd:integer ;
+				observable:endTime "2010-01-15T18:30:41.250000+00:00"^^xsd:dateTime ;
+				observable:from <http://example.org/kb/phone_account1> ;
+				observable:startTime "2010-01-15T17:59:43.250000+00:00"^^xsd:dateTime ;
+				observable:to <http://example.org/kb/phone_account2> ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:PhoneCallFacet ; uco-observable:callType Literal("outgoing") ; uco-observable:duration Literal("1862", datatype=xsd:integer) ; uco-observable:endTime Literal("2010-01-15T18:30:41.250000+00:00" = 2010-01-15 18:30:41.250000+00:00, datatype=xsd:dateTime) ; uco-observable:from kb:phone_account1 ; uco-observable:startTime Literal("2010-01-15T17:59:43.250000+00:00" = 2010-01-15 17:59:43.250000+00:00, datatype=xsd:dateTime) ; uco-observable:to kb:phone_account2 ]->observable:application' ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+		]
+		;
+	.
+

--- a/examples/illustrations/device/Makefile
+++ b/examples/illustrations/device/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/device/device_validation.ttl
+++ b/examples/illustrations/device/device_validation.ttl
@@ -1,0 +1,31 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix ns1: <http://custompb.acme.org/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result [
+		a sh:ValidationResult ;
+		sh:focusNode <http://example.org/kb/forensic_lab_computer1-uuid> ;
+		sh:resultMessage "Value does not have class core:Facet" ;
+		sh:resultPath core:hasFacet ;
+		sh:resultSeverity sh:Violation ;
+		sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+		sh:sourceShape [
+			sh:class core:Facet ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path core:hasFacet ;
+		] ;
+		sh:value [
+			a ns1:InventoryComputer ;
+			ns1:inventoryNumber "10503" ;
+			ns1:name "DFL-03" ;
+		] ;
+	] ;
+	.
+

--- a/examples/illustrations/exif_data/Makefile
+++ b/examples/illustrations/exif_data/Makefile
@@ -15,62 +15,39 @@ SHELL := /bin/bash
 
 top_srcdir := $(shell cd ../../.. ; pwd)
 
-RDF_TOOLKIT_JAR := $(top_srcdir)/dependencies/CASE-0.3.0/CASE/lib/rdf-toolkit.jar
-
-example_name := $(shell basename $$PWD)
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
 
 all: \
-  $(example_name)_validation.ttl \
+  all-review \
   query-select-files.md
 
 .PHONY: \
-  check-0.3.0 \
-  check-0.4.0
+  all-review \
+  check-review \
+  clean-review
 
-$(example_name)_validation.ttl: \
-  $(example_name).json \
-  $(RDF_TOOLKIT_JAR) \
-  $(top_srcdir)/.venv.done.log
-	source $(top_srcdir)/venv/bin/activate \
-	  && case_validate \
-	    --format turtle \
-	    --output __$@ \
-	    $< \
-	    ; rc=$$? ; test 0 -eq $$rc -o 1 -eq $$rc
-	test -s __$@
-	java -jar $(RDF_TOOLKIT_JAR) \
-	  --inline-blank-nodes \
-	  --source __$@ \
-	  --source-format turtle \
-	  --target _$@ \
-	  --target-format turtle
-	rm __$@
-	mv _$@ $@
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
 
 check: \
-  $(example_name)_validation.ttl \
-  check-0.3.0 \
-  check-0.4.0 \
+  check-review \
   query-select-files.md
 
-check-0.3.0: \
-  $(top_srcdir)/.dependencies.done.log
-	source $(top_srcdir)/venv/bin/activate \
-	  && validate \
-	    $(top_srcdir)/dependencies/case-0.3.0.pkl \
-	    exif_data.json
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
 
-check-0.4.0: \
-  $(top_srcdir)/.dependencies.done.log
-	source $(top_srcdir)/venv/bin/activate \
-	  && validate \
-	    $(top_srcdir)/dependencies/case-0.4.0.pkl \
-	    exif_data.json
-
-clean:
+clean: \
+  clean-review
 	@rm -f \
-	  $(example_name)_validation.ttl \
 	  query-*.md
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean
 
 query-select-files.md: \
   $(top_srcdir)/.venv.done.log \

--- a/examples/illustrations/exif_data/Makefile
+++ b/examples/illustrations/exif_data/Makefile
@@ -15,14 +15,40 @@ SHELL := /bin/bash
 
 top_srcdir := $(shell cd ../../.. ; pwd)
 
+RDF_TOOLKIT_JAR := $(top_srcdir)/dependencies/CASE-0.3.0/CASE/lib/rdf-toolkit.jar
+
+example_name := $(shell basename $$PWD)
+
 all: \
+  $(example_name)_validation.ttl \
   query-select-files.md
 
 .PHONY: \
   check-0.3.0 \
   check-0.4.0
 
+$(example_name)_validation.ttl: \
+  $(example_name).json \
+  $(RDF_TOOLKIT_JAR) \
+  $(top_srcdir)/.venv.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --format turtle \
+	    --output __$@ \
+	    $< \
+	    ; rc=$$? ; test 0 -eq $$rc -o 1 -eq $$rc
+	test -s __$@
+	java -jar $(RDF_TOOLKIT_JAR) \
+	  --inline-blank-nodes \
+	  --source __$@ \
+	  --source-format turtle \
+	  --target _$@ \
+	  --target-format turtle
+	rm __$@
+	mv _$@ $@
+
 check: \
+  $(example_name)_validation.ttl \
   check-0.3.0 \
   check-0.4.0 \
   query-select-files.md
@@ -43,6 +69,7 @@ check-0.4.0: \
 
 clean:
 	@rm -f \
+	  $(example_name)_validation.ttl \
 	  query-*.md
 
 query-select-files.md: \

--- a/examples/illustrations/exif_data/exif_data.json
+++ b/examples/illustrations/exif_data/exif_data.json
@@ -14,7 +14,7 @@
     "@graph": [
         {
             "@id": "kb:camera1",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:Device",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:DeviceFacet",
@@ -47,7 +47,7 @@
         },
         {
             "@id": "kb:digital_photograph1",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:File",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",

--- a/examples/illustrations/exif_data/exif_data_validation.ttl
+++ b/examples/illustrations/exif_data/exif_data_validation.ttl
@@ -1,0 +1,182 @@
+@prefix action: <https://unifiedcyberontology.org/ontology/uco/action#> .
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix location: <https://unifiedcyberontology.org/ontology/uco/location#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/annotation1> ;
+			sh:resultMessage "Less than 1 values on kb:annotation1->core:object" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship1> ;
+			sh:resultMessage "Less than 1 values on kb:relationship1->core:isDirectional" ;
+			sh:resultPath core:isDirectional ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:boolean ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:isDirectional ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:target ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:target ;
+			] ;
+			sh:value <http://example.org/kb/device_partition3> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship1> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/annotator_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/annotation1> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/annotator_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/annotation1> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/annotator_tool1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/annotator_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/annotation1> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/examiner1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/annotator_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/annotation1> ;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:instrument <http://example.org/kb/camera1> ;
+				action:location <http://example.org/kb/location1> ;
+				action:result <http://example.org/kb/digital_photograph1> ;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/location1> ;
+		]
+		;
+	.
+

--- a/examples/illustrations/file/Makefile
+++ b/examples/illustrations/file/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/file/file_validation.ttl
+++ b/examples/illustrations/file/file_validation.ttl
@@ -1,0 +1,160 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix ns1: <http://custompb.acme.org/core#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/forensic_lab_computer1-uuid> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a ns1:InventoryComputer ;
+				ns1:inventoryNumber "10503" ;
+				ns1:name "DFL-03" ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship0> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship2> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship4> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship5> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship6> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship7> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:target ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:target ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship8> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:target ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:target ;
+			] ;
+			sh:value <http://example.org/kb/android_device1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:DiskPartitionFacet ;
+				observable:partitionID "3"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath observable:partitionID ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:partitionID ;
+			] ;
+			sh:value "3"^^xsd:integer ;
+		]
+		;
+	.
+

--- a/examples/illustrations/forensic_lifecycle/Makefile
+++ b/examples/illustrations/forensic_lifecycle/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/forensic_lifecycle/forensic_lifecycle_validation.ttl
+++ b/examples/illustrations/forensic_lifecycle/forensic_lifecycle_validation.ttl
@@ -1,0 +1,1728 @@
+@prefix action: <https://unifiedcyberontology.org/ontology/uco/action#> .
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix investigation: <https://ontology.caseontology.org/case/investigation/> .
+@prefix location: <https://unifiedcyberontology.org/ontology/uco/location#> .
+@prefix ns1: <http://custompb.acme.org/core#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix types: <https://unifiedcyberontology.org/ontology/uco/types#> .
+@prefix vocab: <https://ontology.caseontology.org/case/vocabulary/> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Less than 1 values on kb:case1->investigation:investigationForm" ;
+			sh:resultPath investigation:investigationForm ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocab:InvestigationFormVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path investigation:investigationForm ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/account1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/account2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/android_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/attachment_file> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/chat_messages_report> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/config_file> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/decoded_blob> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/decrypted_blob> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/device1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/examiner1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/examiner2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/fedex_dropoff_location1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/image_partition> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/investigator1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/location1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/log_file> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/message1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/message_action1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/message_database> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/os1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/parser1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/plaso_storage_file> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/sd_card1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/sd_card1_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/sqlite_blob> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/subject1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/thread1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/thumbnail_database> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/tool1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/tool2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/tool3> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/victim2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/case1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/windows_registries_report> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/forensic_action3> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a ns1:UFEDArguments ;
+				ns1:aquisitionType "Logical" ;
+				ns1:method "ADB" ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/forensic_action5> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a ns1:PlasoArguments ;
+				ns1:analysisReport
+					<http://example.org/kb/chat_messages_report> ,
+					<http://example.org/kb/windows_registries_report>
+					;
+				ns1:configFile <http://example.org/kb/config_file> ;
+				ns1:input <http://example.org/kb/android_image> ;
+				ns1:logFile <http://example.org/kb/log_file> ;
+				ns1:storageFile <http://example.org/kb/plaso_storage_file> ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/forensic_action6> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a ns1:PlasoParserArguments ;
+				ns1:attachmentFile
+					<http://example.org/kb/attachment_file> ,
+					<http://example.org/kb/thumbnail_database>
+					;
+				ns1:fullQueryMatch "true"^^xsd:boolean ;
+				ns1:parsedFile <http://example.org/kb/message_database> ;
+				ns1:query "SELECT sender, recipients, body from MessageTable" ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/forensic_lifecycle1> ;
+			sh:resultMessage "Less than 1 values on kb:forensic_lifecycle1->action:phase" ;
+			sh:resultPath action:phase ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:class action:ArrayOfAction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:phase ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/lifecycle_phase1> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Mapped_Into"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/lifecycle_phase2> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Mapped_Into"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/lifecycle_phase3> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Mapped_Into"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/lifecycle_phase4> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Mapped_Into"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/lifecycle_phase5> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Mapped_Into"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/device1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record10> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/message_database> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record11> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/thumbnail_database> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record12> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/image_partition> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record13> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/message_action1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record14> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/thread1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record15> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/message1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record16> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/location1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record17> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/account1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record18> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/account2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record19> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/decoded_blob> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record2> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/device1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record20> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/decrypted_blob> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record21> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/sqlite_blob> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record3> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/sd_card1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record4> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/android_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record5> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/sd_card1_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record6> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/chat_messages_report> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record7> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/plaso_storage_file> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record8> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/os1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/provenance_record9> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:object ;
+			] ;
+			sh:value <http://example.org/kb/attachment_file> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/parser1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record9>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/provenance_record13> ,
+					<http://example.org/kb/provenance_record14> ,
+					<http://example.org/kb/provenance_record15> ,
+					<http://example.org/kb/provenance_record16> ,
+					<http://example.org/kb/provenance_record17> ,
+					<http://example.org/kb/provenance_record18> ,
+					<http://example.org/kb/provenance_record19> ,
+					<http://example.org/kb/provenance_record20> ,
+					<http://example.org/kb/provenance_record21>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/parser1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record9>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/provenance_record13> ,
+					<http://example.org/kb/provenance_record14> ,
+					<http://example.org/kb/provenance_record15> ,
+					<http://example.org/kb/provenance_record16> ,
+					<http://example.org/kb/provenance_record17> ,
+					<http://example.org/kb/provenance_record18> ,
+					<http://example.org/kb/provenance_record19> ,
+					<http://example.org/kb/provenance_record20> ,
+					<http://example.org/kb/provenance_record21>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/parser1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/parser1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record9>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/provenance_record13> ,
+					<http://example.org/kb/provenance_record14> ,
+					<http://example.org/kb/provenance_record15> ,
+					<http://example.org/kb/provenance_record16> ,
+					<http://example.org/kb/provenance_record17> ,
+					<http://example.org/kb/provenance_record18> ,
+					<http://example.org/kb/provenance_record19> ,
+					<http://example.org/kb/provenance_record20> ,
+					<http://example.org/kb/provenance_record21>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/examiner2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/parser1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record9>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/provenance_record13> ,
+					<http://example.org/kb/provenance_record14> ,
+					<http://example.org/kb/provenance_record15> ,
+					<http://example.org/kb/provenance_record16> ,
+					<http://example.org/kb/provenance_record17> ,
+					<http://example.org/kb/provenance_record18> ,
+					<http://example.org/kb/provenance_record19> ,
+					<http://example.org/kb/provenance_record20> ,
+					<http://example.org/kb/provenance_record21>
+					;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/device1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record4> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/device1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record4> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/tool1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/device1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record4> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:object ;
+			] ;
+			sh:value <http://example.org/kb/device1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/device1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record4> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/examiner1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/device1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record4> ;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool2> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/sd_card1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record5> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool2> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/sd_card1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record5> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/tool2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool2> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/sd_card1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record5> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:object ;
+			] ;
+			sh:value <http://example.org/kb/sd_card1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool2> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/sd_card1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record5> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/examiner1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool2> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/sd_card1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result <http://example.org/kb/provenance_record5> ;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool3> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/android_image> ,
+					<http://example.org/kb/sd_card1_image>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/forensic_action6> ,
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record12> ,
+					<http://example.org/kb/provenance_record6> ,
+					<http://example.org/kb/provenance_record7> ,
+					<http://example.org/kb/provenance_record8> ,
+					<http://example.org/kb/provenance_record9>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool3> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/android_image> ,
+					<http://example.org/kb/sd_card1_image>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/forensic_action6> ,
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record12> ,
+					<http://example.org/kb/provenance_record6> ,
+					<http://example.org/kb/provenance_record7> ,
+					<http://example.org/kb/provenance_record8> ,
+					<http://example.org/kb/provenance_record9>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/tool3> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool3> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/android_image> ,
+					<http://example.org/kb/sd_card1_image>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/forensic_action6> ,
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record12> ,
+					<http://example.org/kb/provenance_record6> ,
+					<http://example.org/kb/provenance_record7> ,
+					<http://example.org/kb/provenance_record8> ,
+					<http://example.org/kb/provenance_record9>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:object ;
+			] ;
+			sh:value <http://example.org/kb/android_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool3> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/android_image> ,
+					<http://example.org/kb/sd_card1_image>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/forensic_action6> ,
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record12> ,
+					<http://example.org/kb/provenance_record6> ,
+					<http://example.org/kb/provenance_record7> ,
+					<http://example.org/kb/provenance_record8> ,
+					<http://example.org/kb/provenance_record9>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:object ;
+			] ;
+			sh:value <http://example.org/kb/sd_card1_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool3> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/android_image> ,
+					<http://example.org/kb/sd_card1_image>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/forensic_action6> ,
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record12> ,
+					<http://example.org/kb/provenance_record6> ,
+					<http://example.org/kb/provenance_record7> ,
+					<http://example.org/kb/provenance_record8> ,
+					<http://example.org/kb/provenance_record9>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/examiner2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/tool3> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/android_image> ,
+					<http://example.org/kb/sd_card1_image>
+					;
+				action:performer <http://example.org/kb/examiner2> ;
+				action:result
+					<http://example.org/kb/forensic_action6> ,
+					<http://example.org/kb/provenance_record10> ,
+					<http://example.org/kb/provenance_record11> ,
+					<http://example.org/kb/provenance_record12> ,
+					<http://example.org/kb/provenance_record6> ,
+					<http://example.org/kb/provenance_record7> ,
+					<http://example.org/kb/provenance_record8> ,
+					<http://example.org/kb/provenance_record9>
+					;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:location <http://example.org/kb/fedex_dropoff_location1> ;
+				action:object <http://example.org/kb/device1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result
+					<http://example.org/kb/provenance_record2> ,
+					<http://example.org/kb/provenance_record3>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:object ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:object ;
+			] ;
+			sh:value <http://example.org/kb/device1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:location <http://example.org/kb/fedex_dropoff_location1> ;
+				action:object <http://example.org/kb/device1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result
+					<http://example.org/kb/provenance_record2> ,
+					<http://example.org/kb/provenance_record3>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/examiner1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:location <http://example.org/kb/fedex_dropoff_location1> ;
+				action:object <http://example.org/kb/device1> ;
+				action:performer <http://example.org/kb/examiner1> ;
+				action:result
+					<http://example.org/kb/provenance_record2> ,
+					<http://example.org/kb/provenance_record3>
+					;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/fedex_dropoff_location1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:performer <http://example.org/kb/investigator1> ;
+				action:result <http://example.org/kb/provenance_record1> ;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/investigator1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ProcessFacet ;
+				observable:arguments "log2timeline C:\\exams\\inbox\\case-123.img C:\\exams\\output\\case-123 --config C:\\plaso\\config.cfg --analysis chat_messages,windows_registries --output xlsx,pstorage --parsers sqlite/android_whatsapp,plist --log C:\\exams\\output\\case-123.log" ;
+				observable:creatorUser <http://example.org/kb/role4> ;
+				observable:currentWorkingDirectory "C:\\exams" ;
+				observable:environmentVariables [
+					a types:Dictionary ;
+					types:entry [
+						a types:DictionaryEntry ;
+						types:key "PYTHONPATH" ;
+						types:value "C:\\Python27\\Scripts\\python.exe" ;
+					] ;
+				] ;
+				observable:isHidden "false"^^xsd:boolean ;
+				observable:observableCreatedTime "2010-01-20T17:59:43.250000+00:00"^^xsd:dateTime ;
+				observable:pid "1234"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:creatorUser ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:creatorUser ;
+			] ;
+			sh:value <http://example.org/kb/role4> ;
+		]
+		;
+	.
+

--- a/examples/illustrations/location/Makefile
+++ b/examples/illustrations/location/Makefile
@@ -15,56 +15,32 @@ SHELL := /bin/bash
 
 top_srcdir := $(shell cd ../../.. ; pwd)
 
-RDF_TOOLKIT_JAR := $(top_srcdir)/dependencies/CASE-0.3.0/CASE/lib/rdf-toolkit.jar
-
-example_name := $(shell basename $$PWD)
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
 
 all: \
-  $(example_name)_validation.ttl
+  all-review
 
 .PHONY: \
-  check-0.3.0 \
-  check-0.4.0
+  all-review \
+  check-review \
+  clean-review
 
-$(example_name)_validation.ttl: \
-  $(example_name).json \
-  $(RDF_TOOLKIT_JAR) \
-  $(top_srcdir)/.venv.done.log
-	source $(top_srcdir)/venv/bin/activate \
-	  && case_validate \
-	    --format turtle \
-	    --output __$@ \
-	    $< \
-	    ; rc=$$? ; test 0 -eq $$rc -o 1 -eq $$rc
-	test -s __$@
-	java -jar $(RDF_TOOLKIT_JAR) \
-	  --inline-blank-nodes \
-	  --source __$@ \
-	  --source-format turtle \
-	  --target _$@ \
-	  --target-format turtle
-	rm __$@
-	mv _$@ $@
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
 
 check: \
-  $(example_name)_validation.ttl \
-  check-0.3.0 \
-  check-0.4.0
+  check-review
 
-check-0.3.0: \
-  $(top_srcdir)/.dependencies.done.log
-	source $(top_srcdir)/venv/bin/activate \
-	  && validate \
-	    $(top_srcdir)/dependencies/case-0.3.0.pkl \
-	    location.json
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
 
-check-0.4.0: \
-  $(top_srcdir)/.dependencies.done.log
-	source $(top_srcdir)/venv/bin/activate \
-	  && validate \
-	    $(top_srcdir)/dependencies/case-0.4.0.pkl \
-	    location.json
+clean: \
+  clean-review
 
-clean:
-	@rm -f \
-	  $(example_name)_validation.ttl
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/location/Makefile
+++ b/examples/illustrations/location/Makefile
@@ -15,13 +15,39 @@ SHELL := /bin/bash
 
 top_srcdir := $(shell cd ../../.. ; pwd)
 
-all:
+RDF_TOOLKIT_JAR := $(top_srcdir)/dependencies/CASE-0.3.0/CASE/lib/rdf-toolkit.jar
+
+example_name := $(shell basename $$PWD)
+
+all: \
+  $(example_name)_validation.ttl
 
 .PHONY: \
   check-0.3.0 \
   check-0.4.0
 
+$(example_name)_validation.ttl: \
+  $(example_name).json \
+  $(RDF_TOOLKIT_JAR) \
+  $(top_srcdir)/.venv.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --format turtle \
+	    --output __$@ \
+	    $< \
+	    ; rc=$$? ; test 0 -eq $$rc -o 1 -eq $$rc
+	test -s __$@
+	java -jar $(RDF_TOOLKIT_JAR) \
+	  --inline-blank-nodes \
+	  --source __$@ \
+	  --source-format turtle \
+	  --target _$@ \
+	  --target-format turtle
+	rm __$@
+	mv _$@ $@
+
 check: \
+  $(example_name)_validation.ttl \
   check-0.3.0 \
   check-0.4.0
 
@@ -38,3 +64,7 @@ check-0.4.0: \
 	  && validate \
 	    $(top_srcdir)/dependencies/case-0.4.0.pkl \
 	    location.json
+
+clean:
+	@rm -f \
+	  $(example_name)_validation.ttl

--- a/examples/illustrations/location/location_validation.ttl
+++ b/examples/illustrations/location/location_validation.ttl
@@ -1,0 +1,31 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix ns1: <http://custompb.acme.org/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result [
+		a sh:ValidationResult ;
+		sh:focusNode <http://example.org/kb/location1> ;
+		sh:resultMessage "Value does not have class core:Facet" ;
+		sh:resultPath core:hasFacet ;
+		sh:resultSeverity sh:Violation ;
+		sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+		sh:sourceShape [
+			sh:class core:Facet ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path core:hasFacet ;
+		] ;
+		sh:value [
+			a ns1:InternalLocation ;
+			ns1:floor "3"^^xsd:integer ;
+			ns1:roomNumber "345"^^xsd:integer ;
+		] ;
+	] ;
+	.
+

--- a/examples/illustrations/message/Makefile
+++ b/examples/illustrations/message/Makefile
@@ -15,39 +15,32 @@ SHELL := /bin/bash
 
 top_srcdir := $(shell cd ../../.. ; pwd)
 
-RDF_TOOLKIT_JAR := $(top_srcdir)/dependencies/CASE-0.3.0/CASE/lib/rdf-toolkit.jar
-
-example_name := $(shell basename $$PWD)
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
 
 all: \
-  $(example_name)_validation.ttl
+  all-review
 
-$(example_name)_validation.ttl: \
-  $(example_name).json \
-  $(RDF_TOOLKIT_JAR) \
-  $(top_srcdir)/.venv.done.log
-	source $(top_srcdir)/venv/bin/activate \
-	  && case_validate \
-	    --format turtle \
-	    --output __$@ \
-	    $< \
-	    ; rc=$$? ; test 0 -eq $$rc -o 1 -eq $$rc
-	test -s __$@
-	java -jar $(RDF_TOOLKIT_JAR) \
-	  --inline-blank-nodes \
-	  --source __$@ \
-	  --source-format turtle \
-	  --target _$@ \
-	  --target-format turtle
-	rm __$@
-	mv _$@ $@
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
 
 check: \
-  $(example_name)_validation.ttl
-	source $(top_srcdir)/venv/bin/activate \
-	  && pytest \
-	    --verbose
+  check-review
 
-clean:
-	@rm -f \
-	  $(example_name)_validation.ttl
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/message/Makefile
+++ b/examples/illustrations/message/Makefile
@@ -15,12 +15,39 @@ SHELL := /bin/bash
 
 top_srcdir := $(shell cd ../../.. ; pwd)
 
-all:
+RDF_TOOLKIT_JAR := $(top_srcdir)/dependencies/CASE-0.3.0/CASE/lib/rdf-toolkit.jar
+
+example_name := $(shell basename $$PWD)
+
+all: \
+  $(example_name)_validation.ttl
+
+$(example_name)_validation.ttl: \
+  $(example_name).json \
+  $(RDF_TOOLKIT_JAR) \
+  $(top_srcdir)/.venv.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --format turtle \
+	    --output __$@ \
+	    $< \
+	    ; rc=$$? ; test 0 -eq $$rc -o 1 -eq $$rc
+	test -s __$@
+	java -jar $(RDF_TOOLKIT_JAR) \
+	  --inline-blank-nodes \
+	  --source __$@ \
+	  --source-format turtle \
+	  --target _$@ \
+	  --target-format turtle
+	rm __$@
+	mv _$@ $@
 
 check: \
-  $(top_srcdir)/.venv.done.log
+  $(example_name)_validation.ttl
 	source $(top_srcdir)/venv/bin/activate \
 	  && pytest \
 	    --verbose
 
 clean:
+	@rm -f \
+	  $(example_name)_validation.ttl

--- a/examples/illustrations/message/message_validation.ttl
+++ b/examples/illustrations/message/message_validation.ttl
@@ -1,0 +1,317 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix ns1: <http://purl.org/ontology/olo/core#> .
+@prefix ns2: <http://example.org/local#> .
+@prefix ns3: <http://example.org/draft#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/attach_relationship1> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:source ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:source ;
+			] ;
+			sh:value <http://example.org/kb/location1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/attach_relationship2> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:source ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:source ;
+			] ;
+			sh:value <http://example.org/kb/attachment_file1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/attach_relationship3> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:source ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:source ;
+			] ;
+			sh:value <http://example.org/kb/attachment_file2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MessageThreadFacet ;
+				ns3:visibility "PRIVATE" ;
+				ns2:identifier "billy~sarah@whatsapp.gs.net" ;
+				ns2:messages [
+					ns1:length "3"^^xsd:integer ;
+					ns1:slot
+						[
+							ns1:index "1"^^xsd:integer ;
+							ns1:item <http://example.org/kb/message1> ;
+						] ,
+						[
+							ns1:index "2"^^xsd:integer ;
+							ns1:item <http://example.org/kb/message2> ;
+						] ,
+						[
+							ns1:index "3"^^xsd:integer ;
+							ns1:item <http://example.org/kb/message3> ;
+						]
+						;
+				] ;
+				observable:displayName "Best Friend Chat!!" ;
+				observable:message
+					<http://example.org/kb/message1> ,
+					<http://example.org/kb/message2> ,
+					<http://example.org/kb/message3>
+					;
+				observable:participant
+					<http://example.org/kb/account1> ,
+					<http://example.org/kb/account2>
+					;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:message ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:message ;
+			] ;
+			sh:value <http://example.org/kb/message2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MessageThreadFacet ;
+				ns3:visibility "PRIVATE" ;
+				ns2:identifier "billy~sarah@whatsapp.gs.net" ;
+				ns2:messages [
+					ns1:length "3"^^xsd:integer ;
+					ns1:slot
+						[
+							ns1:index "1"^^xsd:integer ;
+							ns1:item <http://example.org/kb/message1> ;
+						] ,
+						[
+							ns1:index "2"^^xsd:integer ;
+							ns1:item <http://example.org/kb/message2> ;
+						] ,
+						[
+							ns1:index "3"^^xsd:integer ;
+							ns1:item <http://example.org/kb/message3> ;
+						]
+						;
+				] ;
+				observable:displayName "Best Friend Chat!!" ;
+				observable:message
+					<http://example.org/kb/message1> ,
+					<http://example.org/kb/message2> ,
+					<http://example.org/kb/message3>
+					;
+				observable:participant
+					<http://example.org/kb/account1> ,
+					<http://example.org/kb/account2>
+					;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:message ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:message ;
+			] ;
+			sh:value <http://example.org/kb/message3> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ApplicationAccountFacet ;
+				observable:application <http://example.org/kb/application2> ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+			sh:value <http://example.org/kb/application2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ApplicationAccountFacet ;
+				observable:application <http://example.org/kb/application2> ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+			sh:value <http://example.org/kb/application2> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AttachmentFacet ;
+				observable:url "http://maps.google.com/maps/@32.5345,-123.4324,11z" ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:url ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:url ;
+			] ;
+			sh:value "http://maps.google.com/maps/@32.5345,-123.4324,11z" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AttachmentFacet ;
+				observable:url "http://maps.google.com/maps/@32.5345,-123.4324,11z" ;
+			] ;
+			sh:resultMessage "Value is not of Node Kind sh:BlankNodeOrIRI" ;
+			sh:resultPath observable:url ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:url ;
+			] ;
+			sh:value "http://maps.google.com/maps/@32.5345,-123.4324,11z" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AttachmentFacet ;
+				observable:url "http://whatsapp.com/attachments/1.png" ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:url ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:url ;
+			] ;
+			sh:value "http://whatsapp.com/attachments/1.png" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AttachmentFacet ;
+				observable:url "http://whatsapp.com/attachments/1.png" ;
+			] ;
+			sh:resultMessage "Value is not of Node Kind sh:BlankNodeOrIRI" ;
+			sh:resultPath observable:url ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:url ;
+			] ;
+			sh:value "http://whatsapp.com/attachments/1.png" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AttachmentFacet ;
+				observable:url "http://whatsapp.com/attachments/thumbnails/1.png" ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:url ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:url ;
+			] ;
+			sh:value "http://whatsapp.com/attachments/thumbnails/1.png" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AttachmentFacet ;
+				observable:url "http://whatsapp.com/attachments/thumbnails/1.png" ;
+			] ;
+			sh:resultMessage "Value is not of Node Kind sh:BlankNodeOrIRI" ;
+			sh:resultPath observable:url ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:url ;
+			] ;
+			sh:value "http://whatsapp.com/attachments/thumbnails/1.png" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MessageFacet ;
+				observable:application <http://example.org/kb/application2> ;
+				observable:from <http://example.org/kb/account3> ;
+				observable:messageText "I said some things in a tweet! @sarahsmithtweeter #hashtag" ;
+				observable:sentTime "2010-01-16T16:34:56.250000+00:00"^^xsd:dateTime ;
+				observable:to <http://example.org/kb/account4> ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+			sh:value <http://example.org/kb/application2> ;
+		]
+		;
+	.
+

--- a/examples/illustrations/mobile_device_and_sim_card/Makefile
+++ b/examples/illustrations/mobile_device_and_sim_card/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/mobile_device_and_sim_card/mobile_device_and_sim_card_validation.ttl
+++ b/examples/illustrations/mobile_device_and_sim_card/mobile_device_and_sim_card_validation.ttl
@@ -1,0 +1,195 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix identity: <https://unifiedcyberontology.org/ontology/uco/identity#> .
+@prefix ns1: <http://example.org/local#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship1-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:SIMCardFacet ;
+				ns1:IMSI <http://example.org/kb/mobile-account2-uuid> ;
+				observable:ICCID "456673345673436xxx" ;
+				observable:SIMForm "micro" ;
+				observable:SIMType "USIM" ;
+				observable:carrier "Vodafone" ;
+			] ;
+			sh:resultMessage "Value does not have class identity:Identity" ;
+			sh:resultPath observable:carrier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class identity:Identity ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:carrier ;
+			] ;
+			sh:value "Vodafone" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:SIMCardFacet ;
+				ns1:IMSI <http://example.org/kb/mobile-account2-uuid> ;
+				observable:ICCID "456673345673436xxx" ;
+				observable:SIMForm "micro" ;
+				observable:SIMType "USIM" ;
+				observable:carrier "Vodafone" ;
+			] ;
+			sh:resultMessage "Value is not of Node Kind sh:BlankNodeOrIRI" ;
+			sh:resultPath observable:carrier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:class identity:Identity ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:carrier ;
+			] ;
+			sh:value "Vodafone" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountType Literal("Phone") ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:AccountTypeVocab" ;
+			sh:resultPath observable:accountType ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:AccountTypeVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountType ;
+			] ;
+			sh:value "Phone" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountType Literal("Phone") ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:AccountTypeVocab" ;
+			sh:resultPath observable:accountType ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:AccountTypeVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountType ;
+			] ;
+			sh:value "Phone" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MobileDeviceFacet ;
+				observable:IMEI "35540607448XXXX" ;
+				observable:MSISDN <http://example.org/kb/mobile-account1-uuid> ;
+				observable:clockSetting "2018-02-24T07:36:24.350000+00:00"^^xsd:dateTime ;
+				observable:keypadUnlockCode "123456" ;
+				observable:storageCapacityInBytes "17179869184"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath observable:MSISDN ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:MSISDN ;
+			] ;
+			sh:value <http://example.org/kb/mobile-account1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MobileDeviceFacet ;
+				observable:IMEI "35540607448XXXX" ;
+				observable:MSISDN <http://example.org/kb/mobile-account1-uuid> ;
+				observable:clockSetting "2018-02-24T07:36:24.350000+00:00"^^xsd:dateTime ;
+				observable:keypadUnlockCode "123456" ;
+				observable:storageCapacityInBytes "17179869184"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not of Node Kind sh:Literal" ;
+			sh:resultPath observable:MSISDN ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:MSISDN ;
+			] ;
+			sh:value <http://example.org/kb/mobile-account1-uuid> ;
+		]
+		;
+	.
+

--- a/examples/illustrations/multipart_file/Makefile
+++ b/examples/illustrations/multipart_file/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/multipart_file/multipart_file_validation.ttl
+++ b/examples/illustrations/multipart_file/multipart_file_validation.ttl
@@ -1,0 +1,108 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship3> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:target ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:target ;
+			] ;
+			sh:value <http://example.org/kb/android_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship3> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship4> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:target ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:target ;
+			] ;
+			sh:value <http://example.org/kb/android_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship4> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship5> ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath core:target ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:target ;
+			] ;
+			sh:value <http://example.org/kb/android_image> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship5> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		]
+		;
+	.
+

--- a/examples/illustrations/network_connection/Makefile
+++ b/examples/illustrations/network_connection/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/network_connection/network_connection_validation.ttl
+++ b/examples/illustrations/network_connection/network_connection_validation.ttl
@@ -1,0 +1,436 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix investigation: <https://ontology.caseontology.org/case/investigation/> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix tool: <https://unifiedcyberontology.org/ontology/uco/tool#> .
+@prefix vocab: <https://ontology.caseontology.org/case/vocabulary/> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/destination-host-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/investigator1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/extracted-connections-provenancerecord-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/investigator1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/extraction-action-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/investigator1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-952d677d-6b62-4e53-9bac-1b113d268ac5> ;
+			sh:resultMessage "Less than 1 values on kb:investigation-952d677d-6b62-4e53-9bac-1b113d268ac5->investigation:investigationForm" ;
+			sh:resultPath investigation:investigationForm ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocab:InvestigationFormVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path investigation:investigationForm ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/investigation-952d677d-6b62-4e53-9bac-1b113d268ac5> ;
+			sh:resultMessage "Value does not have class core:Facet" ;
+			sh:resultPath core:hasFacet ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:Facet ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:hasFacet ;
+			] ;
+			sh:value [
+				a investigation:Authorization ;
+				investigation:authorizationIdentifier "Warrant3554" ;
+				investigation:authorizationType "warrant" ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/network-connection1-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/investigator1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/network-connection2-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/investigator1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/network-connection3-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/investigator1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/pcap-file-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/81ee357b-5fc1-5aa8-b932-ff29ace0f65b> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/pcap-provenancerecord-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/81ee357b-5fc1-5aa8-b932-ff29ace0f65b> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/pcap-tool-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath tool:creator ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path tool:creator ;
+			] ;
+			sh:value <http://example.org/kb/NetworkAnalyserCorporation> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/pcap-tool-uuid> ;
+			sh:resultMessage "Value is not of Node Kind sh:Literal" ;
+			sh:resultPath tool:creator ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path tool:creator ;
+			] ;
+			sh:value <http://example.org/kb/NetworkAnalyserCorporation> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/source-host-uuid> ;
+			sh:resultMessage "Value does not have class core:IdentityAbstraction" ;
+			sh:resultPath core:createdBy ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:IdentityAbstraction ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path core:createdBy ;
+			] ;
+			sh:value <http://example.org/kb/investigator1-uuid> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship1-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:boolean" ;
+			sh:resultPath core:isDirectional ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:boolean ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:isDirectional ;
+			] ;
+			sh:value "true" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship1-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship2-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:boolean" ;
+			sh:resultPath core:isDirectional ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:boolean ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:isDirectional ;
+			] ;
+			sh:value "true" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship2-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship3-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:boolean" ;
+			sh:resultPath core:isDirectional ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:boolean ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:isDirectional ;
+			] ;
+			sh:value "true" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/trace-relationship3-uuid> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:IPv4AddressFacet ;
+				observable:value "10.10.10.2" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:IPv4AddressFacet ; uco-observable:value Literal("10.10.10.2") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:IPv4AddressFacet ;
+				observable:value "10.10.10.2" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:IPv4AddressFacet ; uco-observable:value Literal("10.10.10.2") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:IPv4AddressFacet ;
+				observable:value "10.10.10.2" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:IPv4AddressFacet ; uco-observable:value Literal("10.10.10.2") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:IPv4AddressFacet ;
+				observable:value "10.10.10.50" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:IPv4AddressFacet ; uco-observable:value Literal("10.10.10.50") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:IPv4AddressFacet ;
+				observable:value "10.10.10.50" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:IPv4AddressFacet ; uco-observable:value Literal("10.10.10.50") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:IPv4AddressFacet ;
+				observable:value "10.10.10.50" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:IPv4AddressFacet ; uco-observable:value Literal("10.10.10.50") ]->observable:addressValue' ;
+			sh:resultPath observable:addressValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:addressValue ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:URLFacet ;
+				observable:path "E:\\Traffic\\20090402-scenario.pcap" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:URLFacet ; uco-observable:path Literal("E:\\Traffic\\20090402-scenario.pcap") ]->observable:fullValue' ;
+			sh:resultPath observable:fullValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:fullValue ;
+			] ;
+		]
+		;
+	.
+

--- a/examples/illustrations/raw_data/Makefile
+++ b/examples/illustrations/raw_data/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/raw_data/raw_data_validation.ttl
+++ b/examples/illustrations/raw_data/raw_data_validation.ttl
@@ -1,0 +1,71 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix types: <https://unifiedcyberontology.org/ontology/uco/types#> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship0> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "MD5"^^core:HashNameEnum ;
+				types:hashValue "3d137a188c1e82247b815209ce44af2c"^^xsd:hexbinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:HashNameVocab" ;
+			sh:resultPath types:hashMethod ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:HashNameVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashMethod ;
+			] ;
+			sh:value "MD5"^^core:HashNameEnum ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a types:Hash ;
+				types:hashMethod "MD5"^^core:HashNameEnum ;
+				types:hashValue "3d137a188c1e82247b815209ce44af2c"^^xsd:hexbinary ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:hexBinary" ;
+			sh:resultPath types:hashValue ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:hexBinary ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path types:hashValue ;
+			] ;
+			sh:value "3d137a188c1e82247b815209ce44af2c"^^xsd:hexbinary ;
+		]
+		;
+	.
+

--- a/examples/illustrations/reconstructed_file/Makefile
+++ b/examples/illustrations/reconstructed_file/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/reconstructed_file/reconstructed_file_validation.ttl
+++ b/examples/illustrations/reconstructed_file/reconstructed_file_validation.ttl
@@ -1,0 +1,408 @@
+@prefix action: <https://unifiedcyberontology.org/ontology/uco/action#> .
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix location: <https://unifiedcyberontology.org/ontology/uco/location#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix types: <https://unifiedcyberontology.org/ontology/uco/types#> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship3> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship4> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode <http://example.org/kb/relationship5> ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath core:kindOfRelationship ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path core:kindOfRelationship ;
+			] ;
+			sh:value "Contained_Within"^^vocabulary1:ObservableObjectRelationshipVocab ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/carving_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/android_image> ;
+				action:performer <http://example.org/kb/role4> ;
+				action:result
+					<http://example.org/kb/data_piece1> ,
+					<http://example.org/kb/data_piece2> ,
+					<http://example.org/kb/provenance_record2> ,
+					<http://example.org/kb/relationship3> ,
+					<http://example.org/kb/relationship4>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/carving_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/android_image> ;
+				action:performer <http://example.org/kb/role4> ;
+				action:result
+					<http://example.org/kb/data_piece1> ,
+					<http://example.org/kb/data_piece2> ,
+					<http://example.org/kb/provenance_record2> ,
+					<http://example.org/kb/relationship3> ,
+					<http://example.org/kb/relationship4>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/carving_tool1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/carving_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/android_image> ;
+				action:performer <http://example.org/kb/role4> ;
+				action:result
+					<http://example.org/kb/data_piece1> ,
+					<http://example.org/kb/data_piece2> ,
+					<http://example.org/kb/provenance_record2> ,
+					<http://example.org/kb/relationship3> ,
+					<http://example.org/kb/relationship4>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/role4> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/carving_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object <http://example.org/kb/android_image> ;
+				action:performer <http://example.org/kb/role4> ;
+				action:result
+					<http://example.org/kb/data_piece1> ,
+					<http://example.org/kb/data_piece2> ,
+					<http://example.org/kb/provenance_record2> ,
+					<http://example.org/kb/relationship3> ,
+					<http://example.org/kb/relationship4>
+					;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/carving_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/data_piece0> ,
+					<http://example.org/kb/data_piece1> ,
+					<http://example.org/kb/data_piece2>
+					;
+				action:performer <http://example.org/kb/role4> ;
+				action:result
+					<http://example.org/kb/provenance_record1> ,
+					<http://example.org/kb/reconstructed_file> ,
+					<http://example.org/kb/relationship0> ,
+					<http://example.org/kb/relationship1> ,
+					<http://example.org/kb/relationship2>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:environment ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:environment ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab_computer1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/carving_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/data_piece0> ,
+					<http://example.org/kb/data_piece1> ,
+					<http://example.org/kb/data_piece2>
+					;
+				action:performer <http://example.org/kb/role4> ;
+				action:result
+					<http://example.org/kb/provenance_record1> ,
+					<http://example.org/kb/reconstructed_file> ,
+					<http://example.org/kb/relationship0> ,
+					<http://example.org/kb/relationship1> ,
+					<http://example.org/kb/relationship2>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:instrument ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:instrument ;
+			] ;
+			sh:value <http://example.org/kb/carving_tool1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/carving_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/data_piece0> ,
+					<http://example.org/kb/data_piece1> ,
+					<http://example.org/kb/data_piece2>
+					;
+				action:performer <http://example.org/kb/role4> ;
+				action:result
+					<http://example.org/kb/provenance_record1> ,
+					<http://example.org/kb/reconstructed_file> ,
+					<http://example.org/kb/relationship0> ,
+					<http://example.org/kb/relationship1> ,
+					<http://example.org/kb/relationship2>
+					;
+			] ;
+			sh:resultMessage "Value does not have class core:UcoObject" ;
+			sh:resultPath action:performer ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class core:UcoObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:performer ;
+			] ;
+			sh:value <http://example.org/kb/role4> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a action:ActionReferencesFacet ;
+				action:environment <http://example.org/kb/forensic_lab_computer1> ;
+				action:instrument <http://example.org/kb/carving_tool1> ;
+				action:location <http://example.org/kb/forensic_lab1> ;
+				action:object
+					<http://example.org/kb/data_piece0> ,
+					<http://example.org/kb/data_piece1> ,
+					<http://example.org/kb/data_piece2>
+					;
+				action:performer <http://example.org/kb/role4> ;
+				action:result
+					<http://example.org/kb/provenance_record1> ,
+					<http://example.org/kb/reconstructed_file> ,
+					<http://example.org/kb/relationship0> ,
+					<http://example.org/kb/relationship1> ,
+					<http://example.org/kb/relationship2>
+					;
+			] ;
+			sh:resultMessage "Value does not have class location:Location" ;
+			sh:resultPath action:location ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class location:Location ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path action:location ;
+			] ;
+			sh:value <http://example.org/kb/forensic_lab1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ContentDataFacet ;
+				observable:byteOrder "Big-endian"^^vocabulary1:EndiannessTypeVocab ;
+				observable:dataPayload "<base 64 encoded data of the file>"^^xsd:base64Binary ;
+				observable:hash [
+					a types:Hash ;
+					types:hashMethod "SHA256"^^vocabulary1:HashNameVocab ;
+					types:hashValue "a2bfbb3fbcfbf372c3a83ac9b9aad3d0aa4fb8bcc807af7aabcccac94a8d4892"^^xsd:hexBinary ;
+				] ;
+				observable:sizeInBytes "512"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath observable:dataPayload ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:dataPayload ;
+			] ;
+			sh:value "<base 64 encoded data of the file>"^^xsd:base64Binary ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ContentDataFacet ;
+				observable:byteOrder "Big-endian"^^vocabulary1:EndiannessTypeVocab ;
+				observable:dataPayload "<base 64 encoded data of the file>"^^xsd:base64Binary ;
+				observable:hash [
+					a types:Hash ;
+					types:hashMethod "SHA256"^^vocabulary1:HashNameVocab ;
+					types:hashValue "befb6b14790081e9d79e9b533e227791033e952d04b5f07d577ad65d4806a7a9"^^xsd:hexBinary ;
+				] ;
+				observable:sizeInBytes "248"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath observable:dataPayload ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:dataPayload ;
+			] ;
+			sh:value "<base 64 encoded data of the file>"^^xsd:base64Binary ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ContentDataFacet ;
+				observable:byteOrder "Big-endian"^^vocabulary1:EndiannessTypeVocab ;
+				observable:dataPayload "<base 64 encoded data of the file>"^^xsd:base64Binary ;
+				observable:hash [
+					a types:Hash ;
+					types:hashMethod "SHA256"^^vocabulary1:HashNameVocab ;
+					types:hashValue "e5ca3be56f66200a1bb2262e948ac08dbc672bc8033c1ada743787b0c667dea6"^^xsd:hexBinary ;
+				] ;
+				observable:sizeInBytes "774"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath observable:dataPayload ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:dataPayload ;
+			] ;
+			sh:value "<base 64 encoded data of the file>"^^xsd:base64Binary ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ContentDataFacet ;
+				observable:byteOrder "Big-endian"^^vocabulary1:EndiannessTypeVocab ;
+				observable:dataPayload "w7/DmMO/w6AAEEpGSUY="^^xsd:base64Binary ;
+				observable:hash [
+					a types:Hash ;
+					types:hashMethod "SHA256"^^vocabulary1:HashNameVocab ;
+					types:hashValue "a2bfbb3fbcfbf372c3a83ac9b9aad3d0aa4fb8bcc807af7aabcccac94a8d4892"^^xsd:hexBinary ;
+				] ;
+				observable:sizeInBytes "14"^^xsd:integer ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype xsd:string" ;
+			sh:resultPath observable:dataPayload ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:dataPayload ;
+			] ;
+			sh:value "w7/DmMO/w6AAEEpGSUY="^^xsd:base64Binary ;
+		]
+		;
+	.
+

--- a/examples/illustrations/sms_and_contacts/Makefile
+++ b/examples/illustrations/sms_and_contacts/Makefile
@@ -1,0 +1,46 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+SHELL := /bin/bash
+
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+illustrations_srcdir := $(top_srcdir)/examples/illustrations
+
+all: \
+  all-review
+
+.PHONY: \
+  all-review \
+  check-review \
+  clean-review
+
+all-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk
+
+check: \
+  check-review
+
+check-review:
+	$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  check
+
+clean: \
+  clean-review
+
+clean-review:
+	@$(MAKE) \
+	  --file $(illustrations_srcdir)/src/review.mk \
+	  clean

--- a/examples/illustrations/sms_and_contacts/sms_and_contacts_validation.ttl
+++ b/examples/illustrations/sms_and_contacts/sms_and_contacts_validation.ttl
@@ -1,0 +1,232 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix vocabulary1: <https://unifiedcyberontology.org/ontology/uco/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[]
+	a sh:ValidationReport ;
+	sh:conforms "false"^^xsd:boolean ;
+	sh:result
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				rdfs:comment "TODO: Is the accountType necessary? We know its phone account due to the existence of 'PhoneAccount' (duck type model and all that)" ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Less than 1 values on [ rdf:type uco-observable:AccountFacet ; rdfs:comment Literal(\"TODO: Is the accountType necessary? We know its phone account due to the existence of 'PhoneAccount' (duck type model and all that)\") ; uco-observable:accountType Literal(\"Phone\") ; uco-observable:isActive Literal(\"true\" = True, datatype=xsd:boolean) ]->observable:accountIdentifier" ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				rdfs:comment "TODO: Is the accountType necessary? We know its phone account due to the existence of 'PhoneAccount' (duck type model and all that)" ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:AccountTypeVocab" ;
+			sh:resultPath observable:accountType ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:AccountTypeVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountType ;
+			] ;
+			sh:value "Phone" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Email" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountType Literal("Email") ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Email" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:AccountTypeVocab" ;
+			sh:resultPath observable:accountType ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:AccountTypeVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountType ;
+			] ;
+			sh:value "Email" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountType Literal("Phone") ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:AccountTypeVocab" ;
+			sh:resultPath observable:accountType ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:AccountTypeVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountType ;
+			] ;
+			sh:value "Phone" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountType Literal("Phone") ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultPath observable:accountIdentifier ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype xsd:string ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountIdentifier ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:AccountFacet ;
+				observable:accountType "Phone" ;
+				observable:isActive "true"^^xsd:boolean ;
+			] ;
+			sh:resultMessage "Value is not Literal with datatype vocabulary1:AccountTypeVocab" ;
+			sh:resultPath observable:accountType ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:DatatypeConstraintComponent ;
+			sh:sourceShape [
+				sh:datatype vocabulary1:AccountTypeVocab ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:Literal ;
+				sh:path observable:accountType ;
+			] ;
+			sh:value "Phone" ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:ApplicationFacet ;
+				core:name "Android Phonebook" ;
+				observable:applicationIdentifier "com.android.providers.telephony" ;
+				observable:numberOfLaunches "323"^^xsd:integer ;
+				observable:operatingSystem <http://example.org/kb/os1> ;
+				observable:version "2.3.4" ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:operatingSystem ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:operatingSystem ;
+			] ;
+			sh:value <http://example.org/kb/os1> ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:EmailAccountFacet ;
+				observable:value "jdoe@example.com" ;
+			] ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:EmailAccountFacet ; uco-observable:value Literal("jdoe@example.com") ]->observable:emailAddress' ;
+			sh:resultPath observable:emailAddress ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:minCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:emailAddress ;
+			] ;
+		] ,
+		[
+			a sh:ValidationResult ;
+			sh:focusNode [
+				a observable:MessageFacet ;
+				observable:application <http://example.org/kb/sms_application1> ;
+				observable:from <http://example.org/kb/phone_account3> ;
+				observable:messageText "Yo dude! This is my new number." ;
+				observable:sentTime "2010-01-15T17:59:43.250000+00:00"^^xsd:dateTime ;
+				observable:to <http://example.org/kb/phone_account1> ;
+			] ;
+			sh:resultMessage "Value does not have class observable:ObservableObject" ;
+			sh:resultPath observable:application ;
+			sh:resultSeverity sh:Violation ;
+			sh:sourceConstraintComponent sh:ClassConstraintComponent ;
+			sh:sourceShape [
+				sh:class observable:ObservableObject ;
+				sh:maxCount "1"^^xsd:integer ;
+				sh:nodeKind sh:BlankNodeOrIRI ;
+				sh:path observable:application ;
+			] ;
+			sh:value <http://example.org/kb/sms_application1> ;
+		]
+		;
+	.
+

--- a/examples/illustrations/src/review.mk
+++ b/examples/illustrations/src/review.mk
@@ -1,0 +1,73 @@
+#!/usr/bin/make -f
+
+# This software was developed at the National Institute of Standards
+# and Technology by employees of the Federal Government in the course
+# of their official duties. Pursuant to title 17 Section 105 of the
+# United States Code this software is not subject to copyright
+# protection and is in the public domain. NIST assumes no
+# responsibility whatsoever for its use by other parties, and makes
+# no guarantees, expressed or implied, about its quality,
+# reliability, or any other characteristic.
+#
+# We would appreciate acknowledgement if the software is used.
+
+# This Makefile contains generic steps each illustration will follow for content review.
+
+SHELL := /bin/bash
+
+# The expected execution context is in any sibling directory of this Makefile's directory.
+top_srcdir := $(shell cd ../../.. ; pwd)
+
+RDF_TOOLKIT_JAR := $(top_srcdir)/dependencies/CASE-0.3.0/CASE/lib/rdf-toolkit.jar
+
+example_name := $(shell basename $$PWD)
+
+all: \
+  $(example_name)_validation.ttl
+
+.PHONY: \
+  check-0.3.0 \
+  check-0.4.0
+
+$(example_name)_validation.ttl: \
+  $(example_name).json \
+  $(RDF_TOOLKIT_JAR) \
+  $(top_srcdir)/.venv.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --format turtle \
+	    --output __$@ \
+	    $< \
+	    ; rc=$$? ; test 0 -eq $$rc -o 1 -eq $$rc
+	test -s __$@
+	java -jar $(RDF_TOOLKIT_JAR) \
+	  --inline-blank-nodes \
+	  --source __$@ \
+	  --source-format turtle \
+	  --target _$@ \
+	  --target-format turtle
+	rm __$@
+	mv _$@ $@
+
+check: \
+  $(example_name)_validation.ttl \
+  check-0.3.0 \
+  check-0.4.0
+
+check-0.3.0: \
+  $(top_srcdir)/.dependencies.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && validate \
+	    $(top_srcdir)/dependencies/case-0.3.0.pkl \
+	    $(example_name).json
+
+check-0.4.0: \
+  $(top_srcdir)/.dependencies.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && validate \
+	    $(top_srcdir)/dependencies/case-0.4.0.pkl \
+	    $(example_name).json
+
+clean:
+	@rm -f \
+	  $(example_name)_validation.ttl


### PR DESCRIPTION
This patch series bumps `case_utils` to last week's release of 0.3.0, and makes use of two new features:
1. Use of `case_validate` to create a validation graph for each illustration.
2. Use of an explicit `ObservableObject` subclass in the data, to show `case_sparql_select` now recognizes the CASE/UCO subclass hierarchy.