### PR TITLE
Specify some ObservableObject subclasses

### DIFF
--- a/examples/illustrations/Oresteia/Oresteia.json
+++ b/examples/illustrations/Oresteia/Oresteia.json
@@ -458,7 +458,7 @@
         },
         {
             "@id": "kb:cassandra-device-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:Device",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:DeviceFacet",
@@ -489,7 +489,7 @@
         },
         {
             "@id": "kb:cassandra-mobileaccount-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:MobileAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:AccountFacet",
@@ -642,7 +642,7 @@
         },
         {
             "@id": "kb:clytemnestra-device-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:Device",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:DeviceFacet",
@@ -699,7 +699,7 @@
         },
         {
             "@id": "kb:clytemnestra-mobileaccount-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:MobileAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:AccountFacet",
@@ -882,7 +882,10 @@
         },
         {
             "@id": "kb:cassandra-mobiledevice-forensicduplicate-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": [
+                "uco-observable:File",
+                "uco-observable:Image"
+            ],
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",
@@ -934,7 +937,7 @@
             }
         },
         {
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:File",
             "@id": "kb:cassandra-mobiledevice-mmssms-uuid",
             "uco-core:hasFacet": [
                 {
@@ -995,7 +998,7 @@
         },
         {
             "@id": "kb:cassandra-image-partition6-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:FileSystem",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:DiskPartitionFacet",
@@ -1033,7 +1036,7 @@
         },
         {
             "@id": "kb:trace-relationship4-uuid",
-            "@type": "uco-core:Relationship",
+            "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
                 "@id": "kb:cassandra-image-partition6-uuid"
             },

--- a/examples/illustrations/file/file.json
+++ b/examples/illustrations/file/file.json
@@ -14,7 +14,7 @@
     "@graph": [
         {
             "@id": "kb:chunk_of_data",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -64,7 +64,7 @@
         },
         {
             "@id": "kb:decoded_attachment",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -123,7 +123,7 @@
         },
         {
             "@id": "kb:tar_archive_file",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:File",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",
@@ -189,7 +189,7 @@
         },
         {
             "@id": "kb:decrypted_blob",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -236,7 +236,7 @@
         },
         {
             "@id": "kb:sqlite_blob",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -290,7 +290,7 @@
         },
         {
             "@id": "kb:sqlite_database",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:File",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",
@@ -357,7 +357,8 @@
         },
         {
             "@id": "kb:image_partition",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:FileSystem",
+            "rdfs:comment": "TODO As originally drafted, this was untyped, and left to behave simultaneously like a disk partition and file system via relationship5 and relationship6.  This needs discussion with the community as a modeling issue, as a disk partition and a file system have different behaviors.  The DiskPartitionFacet aspect of relationship6 may need to be applied to another object.",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -401,7 +402,10 @@
         },
         {
             "@id": "kb:android_image",
-            "@type": "uco-observable:ObservableObject",
+            "@type": [
+                "uco-observable:File",
+                "uco-observable:Image"
+            ],
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",
@@ -472,7 +476,7 @@
         },
         {
             "@id": "kb:forensic_lab_computer1-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:Device",
             "rdfs:comment": "TODO: This is an inappropriate placement for the location property (both uco-action:location and uco-observable:location).  Need another way to attach :forensic_lab1.  A Relationship object should be used instead.",
             "location": {
                 "@id": "kb:forensic_lab1-uuid"
@@ -506,7 +510,7 @@
         },
         {
             "@id": "kb:android_device1-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:Device",
             "rdfs:comment": "TODO: This is an inappropriate placement for the location property (both uco-action:location and uco-observable:location).  Need another way to attach :forensic_lab1.  A Relationship object should be used instead.",
             "location": {
                 "@id": "kb:forensic_lab1-uuid"

--- a/examples/illustrations/multipart_file/multipart_file.json
+++ b/examples/illustrations/multipart_file/multipart_file.json
@@ -70,7 +70,7 @@
         },
         {
             "@id": "kb:multipart_file",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -98,7 +98,7 @@
         },
         {
             "@id": "kb:data_piece0",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:File",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",
@@ -144,7 +144,7 @@
         },
         {
             "@id": "kb:data_piece1",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:File",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",
@@ -190,7 +190,7 @@
         },
         {
             "@id": "kb:data_piece2",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:File",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",

--- a/examples/illustrations/network_connection/network_connection.json
+++ b/examples/illustrations/network_connection/network_connection.json
@@ -143,7 +143,7 @@
         },
         {
             "@id": "kb:pcap-file-uuid",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:File",
             "uco-core:createdBy": {
                 "@id": "kb:81ee357b-5fc1-5aa8-b932-ff29ace0f65b"
             },

--- a/examples/illustrations/reconstructed_file/reconstructed_file.json
+++ b/examples/illustrations/reconstructed_file/reconstructed_file.json
@@ -71,7 +71,7 @@
         },
         {
             "@id": "kb:reconstructed_file",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -102,7 +102,7 @@
         },
         {
             "@id": "kb:data_piece0",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -133,7 +133,7 @@
         },
         {
             "@id": "kb:data_piece1",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -164,7 +164,7 @@
         },
         {
             "@id": "kb:data_piece2",
-            "@type": "uco-observable:ObservableObject",
+            "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:ContentDataFacet",
@@ -261,7 +261,10 @@
         },
         {
             "@id": "kb:android_image",
-            "@type": "uco-observable:ObservableObject",
+            "@type": [
+                "uco-observable:File",
+                "uco-observable:Image"
+            ],
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:FileFacet",


### PR DESCRIPTION
These subclass additions were done in support of AC-9.  The refinements
are focused on the storage system hierarchy.  Other `ObservableObject`
non-subclassed instances remain available for refinement.

References:
* [AC-9] Publish NIST DFXML Implementation

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>