### PR TITLE
Smooth out cancelled validation jobs

### DIFF
--- a/examples/illustrations/src/review.mk
+++ b/examples/illustrations/src/review.mk
@@ -29,6 +29,7 @@ $(example_name)_validation.ttl: \
   $(example_name).json \
   $(RDF_TOOLKIT_JAR) \
   $(top_srcdir)/.venv.done.log
+	rm -f __$@
 	source $(top_srcdir)/venv/bin/activate \
 	  && case_validate \
 	    --format turtle \


### PR DESCRIPTION
case_validate and pyshacl require the output file to not exist.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>