### PR TITLE
Install wheel package for virtual environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ all: \
 	  && pip install \
 	    --upgrade \
 	    pip \
-	    setuptools
+	    setuptools \
+	    wheel
 	source venv/bin/activate \
 	  && pip install \
 	      dependencies/CASE-Utilities-Python


### PR DESCRIPTION
This removes use of "legacy setup.py" for installing local directories.

References:
* [AC-195] Use Python venv instead of virtualenv to build virtual
  environments for CI

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>