### PR TITLE
CP-92 Examples Update

### DIFF
--- a/examples/illustrations/call_log/call_log.json
+++ b/examples/illustrations/call_log/call_log.json
@@ -107,11 +107,11 @@
         },
         {
             "@id": "kb:phone_call1",
-            "@type": "uco-observable:PhoneCall",
+            "@type": "uco-observable:Call",
             "uco-core:description": "An example of a two-party, one-way phone call that has clear directionality between a caller (from) and receiver (to).",
             "uco-core:hasFacet": [
                 {
-                    "@type": "uco-observable:PhoneCallFacet",
+                    "@type": "uco-observable:CallFacet",
                     "uco-observable:application": {
                         "@id": "kb:application-a5378ee2-32e0-40ba-b31c-3a5c110e7a29"
                     },
@@ -136,11 +136,11 @@
         },
         {
             "@id": "kb:non-directional-phone-call-1",
-            "@type": "uco-observable:PhoneCall",
+            "@type": "uco-observable:Call",
             "uco-core:description": "An example of a two-party, one-way phone call that has does not have clear directionality between a caller (from) and receiver (to).",
             "uco-core:hasFacet": [
                 {
-                    "@type": "uco-observable:PhoneCallFacet",
+                    "@type": "uco-observable:CallFacet",
                     "uco-observable:application": {
                         "@id": "kb:application-79636b28-77c9-4005-b62d-b87a233687ef"
                     },
@@ -167,11 +167,11 @@
         },
         {
             "@id": "kb:multi-participant-phone-call-1",
-            "@type": "uco-observable:PhoneCall",
+            "@type": "uco-observable:Call",
             "uco-core:description": "An example of a three-way call phone call that has clear directionality between a caller (from) and two receivers (to).",
             "uco-core:hasFacet": [
                 {
-                    "@type": "uco-observable:PhoneCallFacet",
+                    "@type": "uco-observable:CallFacet",
                     "uco-observable:application": {
                         "@id": "kb:application-a5378ee2-32e0-40ba-b31c-3a5c110e7a29"
                     },
@@ -201,11 +201,11 @@
         },
         {
             "@id": "kb:conference-bridge-phone-call-1",
-            "@type": "uco-observable:PhoneCall",
+            "@type": "uco-observable:Call",
             "uco-core:description": "An example of a conference bridge phone call that does not have clear directionality between a caller (from) and receivers (to).",
             "uco-core:hasFacet": [
                 {
-                    "@type": "uco-observable:PhoneCallFacet",
+                    "@type": "uco-observable:CallFacet",
                     "uco-observable:application": {
                         "@id": "kb:application-b01d8144-5fa9-44e9-a5f9-668d433b6108"
                     },

--- a/examples/illustrations/call_log/drafting.ttl
+++ b/examples/illustrations/call_log/drafting.ttl
@@ -1,0 +1,79 @@
+@prefix core: <https://unifiedcyberontology.org/ontology/uco/core#> .
+@prefix observable: <https://unifiedcyberontology.org/ontology/uco/observable#> .
+@prefix drafting: <http://example.org/ontology/drafting#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+drafting:Call
+	a
+		owl:Class ,
+		sh:NodeShape
+		;
+	rdfs:subClassOf observable:ObservableObject ;
+	rdfs:label "Call"@en ;
+	rdfs:comment "A call is a connection as part of a realtime cyber communication between one or more parties."@en ;
+	sh:targetClass drafting:Call ;
+	.
+
+drafting:CallFacet
+	a
+		owl:Class ,
+		sh:NodeShape
+		;
+	rdfs:subClassOf core:Facet ;
+	rdfs:label "CallFacet"@en ;
+	rdfs:comment "A call facet is a grouping of characteristics unique to a connection as part of a realtime cyber communication between one or more parties."@en ;
+	sh:property
+		[
+			sh:class observable:ObservableObject ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:minCount "1"^^xsd:integer ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:application ;
+		] ,
+		[
+			sh:class observable:ObservableObject ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:from ;
+		] ,
+		[
+			sh:class observable:ObservableObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:participant ;
+		] ,
+		[
+			sh:class observable:ObservableObject ;
+			sh:nodeKind sh:BlankNodeOrIRI ;
+			sh:path observable:to ;
+		] ,
+		[
+			sh:datatype xsd:dateTime ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:endTime ;
+		] ,
+		[
+			sh:datatype xsd:dateTime ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:startTime ;
+		] ,
+		[
+			sh:datatype xsd:integer ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:duration ;
+		] ,
+		[
+			sh:datatype xsd:string ;
+			sh:maxCount "1"^^xsd:integer ;
+			sh:nodeKind sh:Literal ;
+			sh:path observable:callType ;
+		]
+		;
+	sh:targetClass drafting:CallFacet ;
+	.


### PR DESCRIPTION
Cased on UCO CP-92, update references of `uco-observable:PhoneCall` to `uco-observable:Call` and `uco-observable:PhoneCallFacet` to `uco-observable:CallFacet`