### PR TITLE
Uco issue 361 v2

### DIFF
--- a/examples/illustrations/Oresteia/Oresteia.json
+++ b/examples/illustrations/Oresteia/Oresteia.json
@@ -502,10 +502,6 @@
                         "@value": "2017-06-22T07:36:24.35Z"
                     },
                     "uco-observable:storageCapacityInBytes": 11000000000
-                },
-                {
-                    "@type": "uco-observable:MobileAccountFacet",
-                    "uco-observable:MSISDN": "1239275339"
                 }
             ]
         },
@@ -691,7 +687,6 @@
                     ],
                     "uco-observable:keypadUnlockCode": "123789",
                     "uco-observable:IMEI": "359305065690067",
-                    "uco-observable:MSISDN": "1237471334",
                     "uco-observable:clockSetting": {
                         "@type": "xsd:dateTime",
                         "@value": "2017-06-21T06:36:24.35Z"
@@ -746,6 +741,19 @@
                     "uco-observable:MSISDN": "1237471334"
                 }
             ]
+        },
+        {
+            "@id": "kb:device-account-relationship2",
+            "@type": "uco-core:Relationship",
+            "uco-core:source": {
+                "@id": "kb:clytemnestra-device-uuid"
+            },
+            "uco-core:target": {
+                "@id": "kb:clytemnestra-mobileaccount-uuid"
+            },
+            "rdfs:comment": "TODO: 'Has_Account' is not in uco-vocabulary:ObservableObjectRelationshipVocab.",
+            "uco-core:kindOfRelationship": "Has_Account",
+            "uco-core:isDirectional": true
         },
         {
             "@id": "kb:investigative-action1-uuid",

--- a/examples/illustrations/mobile_device_and_sim_card/mobile_device_and_sim_card.json
+++ b/examples/illustrations/mobile_device_and_sim_card/mobile_device_and_sim_card.json
@@ -41,7 +41,6 @@
                     "@type": "uco-observable:MobileDeviceFacet",
                     "uco-observable:keypadUnlockCode": "123456",
                     "uco-observable:IMEI": "35540607448XXXX",
-                    "uco-observable:MSISDN": "31618300XXX",
                     "uco-observable:clockSetting": {
                         "@type": "xsd:dateTime",
                         "@value": "2018-02-24T07:36:24.35Z"
@@ -101,6 +100,18 @@
             "@id": "kb:organization-2f1365d2-dfbc-4817-9822-77e7b4a9ee9f",
             "@type": "uco-identity:Organization",
             "uco-core:name": "Vodafone"
+        },
+        {
+            "@id": "kb:device-account-relationship1",
+            "@type": "uco-core:Relationship",
+            "uco-core:source": {
+                "@id": "kb:mobile-device-uuid"
+            },
+            "uco-core:target": {
+                "@id": "kb:mobile-account1-uuid"
+            },
+            "uco-core:kindOfRelationship": "Has_Account",
+            "uco-core:isDirectional": true
         },
         {
             "@id": "kb:mobile-account1-uuid",


### PR DESCRIPTION
This supersedes the implementation of [PR 56](https://github.com/casework/CASE-Examples/pull/56).

The original description holds:

> Update examples to remove MSISDN property from MobileDeviceFacet (See UCO Issue #361)