### PR TITLE
Check & Update json example uuids (part 1 of 2) 

### DIFF
--- a/examples/illustrations/accounts/accounts.json
+++ b/examples/illustrations/accounts/accounts.json
@@ -10,7 +10,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:actor1",
+            "@id": "kb:actor1-0058fc60-4b1b-4ad4-ba7e-231d00d40973",
             "@type": "uco-identity:Person",
             "uco-core:hasFacet": [
                 {
@@ -28,74 +28,74 @@
             ]
         },
         {
-            "@id": "kb:application1",
+            "@id": "kb:application1-ed4caa32-84c8-4813-b21d-f350e47cba7c",
             "@type": "uco-observable:Application"
         },
         {
-            "@id": "kb:application2",
+            "@id": "kb:application2-db5e8cbe-70e7-4dff-b981-2c5751b7923c",
             "@type": "uco-observable:Application"
         },
         {
-            "@id": "kb:facebook_org",
+            "@id": "kb:facebook_org-84a47032-567a-4580-9b88-f0141abdc7bf",
             "@type": "uco-identity:Organization",
             "uco-core:name": "Google"
         },
         {
-            "@id": "kb:google_org",
+            "@id": "kb:google_org-e2ec4537-c2d4-46c5-b159-6f90e84c2e71",
             "@type": "uco-identity:Organization",
             "uco-core:name": "Google"
         },
         {
-            "@id": "kb:associated-account1",
+            "@id": "kb:associated-account1-40d3bfa5-b808-4cf3-8f3e-4c8ea2d79686",
             "@type": "uco-core:Relationship",
             "uco-core:source": {
-                "@id": "kb:actor1"
+                "@id": "kb:actor1-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:facebook_account1"
+                    "@id": "kb:facebook_account1-c188af2d-9651-44a8-8d4c-07a1f5f1aa20"
                 }
             ],
             "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:associated-account2",
+            "@id": "kb:associated-account2-6620a818-7584-4760-a2cf-ff91aa742205",
             "@type": "uco-core:Relationship",
             "uco-core:source": {
-                "@id": "kb:actor1"
+                "@id": "kb:actor1-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:google_account1"
+                    "@id": "kb:google_account1-f514a133-bca6-488c-a0a3-44c40f9ac766"
                 }
             ],
             "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:associated-account3",
+            "@id": "kb:associated-account3-db2cb91c-c31d-496e-9802-bb15f24aa8c5",
             "@type": "uco-core:Relationship",
             "uco-core:source": {
-                "@id": "kb:actor1"
+                "@id": "kb:actor1-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:email_account1"
+                    "@id": "kb:email_account1-e798e18c-0bef-4883-83df-e2710c4bc7e4"
                 }
             ],
             "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:facebook_account1",
+            "@id": "kb:facebook_account1-c188af2d-9651-44a8-8d4c-07a1f5f1aa20",
             "@type": "uco-observable:DigitalAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIdentifier": "1235556677@facebook.net",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:facebook_org"
+                        "@id": "kb:facebook_org-84a47032-567a-4580-9b88-f0141abdc7bf"
                     }
                 },
                 {
@@ -122,7 +122,7 @@
                 {
                     "@type": "uco-observable:ApplicationAccountFacet",
                     "uco-observable:application": {
-                        "@id": "kb:application1"
+                        "@id": "kb:application1-ed4caa32-84c8-4813-b21d-f350e47cba7c"
                     }
                 },
                 {
@@ -140,29 +140,29 @@
             ]
         },
         {
-            "@id": "kb:associated-account4",
+            "@id": "kb:associated-account4-419252da-6d0b-4f93-b070-75b9a5bc1cc2",
             "@type": "uco-core:Relationship",
             "rdfs:comment": "It is possible isDirectional should be false.  This is being tracked in UCO OC-135.",
             "uco-core:source": {
-                "@id": "kb:facebook_account1"
+                "@id": "kb:facebook_account1-c188af2d-9651-44a8-8d4c-07a1f5f1aa20"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:email_account1"
+                    "@id": "kb:email_account1-e798e18c-0bef-4883-83df-e2710c4bc7e4"
                 }
             ],
             "uco-core:kindOfRelationship": "Associated_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:google_account1",
+            "@id": "kb:google_account1-f514a133-bca6-488c-a0a3-44c40f9ac766",
             "@type": "uco-observable:DigitalAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIdentifier": "willyROX@gmail.com",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:google_org"
+                        "@id": "kb:google_org-e2ec4537-c2d4-46c5-b159-6f90e84c2e71"
                     },
                     "uco-observable:observableCreatedTime": {
                         "@type": "xsd:dateTime",
@@ -196,7 +196,7 @@
                 {
                     "@type": "uco-observable:ApplicationAccountFacet",
                     "uco-observable:application": {
-                        "@id": "kb:application2"
+                        "@id": "kb:application2-db5e8cbe-70e7-4dff-b981-2c5751b7923c"
                     }
                 },
                 {
@@ -214,34 +214,34 @@
             ]
         },
         {
-            "@id": "kb:associated-account4",
+            "@id": "kb:associated-account5-8222be1c-1e4a-4c1d-a631-bb3aa9743971",
             "@type": "uco-observable:ObservableRelationship",
             "rdfs:comment": "It is possible isDirectional should be false.  This is being tracked in UCO OC-135.",
             "uco-core:source": {
-                "@id": "kb:google_account1"
+                "@id": "kb:google_account1-f514a133-bca6-488c-a0a3-44c40f9ac766"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:email_account1"
+                    "@id": "kb:email_account1-e798e18c-0bef-4883-83df-e2710c4bc7e4"
                 }
             ],
             "uco-core:kindOfRelationship": "Associated_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:email_account1",
+            "@id": "kb:email_account1-e798e18c-0bef-4883-83df-e2710c4bc7e4",
             "@type": "uco-observable:EmailAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:EmailAccountFacet",
                     "uco-observable:emailAddress": {
-                        "@id": "kb:email-address1"
+                        "@id": "kb:email-address1-eeb346b0-470d-402b-b9ce-17134b1c572e"
                     }
                 }
             ]
         },
         {
-            "@id": "kb:email-address1",
+            "@id": "kb:email-address1-eeb346b0-470d-402b-b9ce-17134b1c572e",
             "@type": "uco-observable:EmailAddress",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/accounts/accounts.json
+++ b/examples/illustrations/accounts/accounts.json
@@ -10,7 +10,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:actor1-0058fc60-4b1b-4ad4-ba7e-231d00d40973",
+            "@id": "kb:actor-0058fc60-4b1b-4ad4-ba7e-231d00d40973",
             "@type": "uco-identity:Person",
             "uco-core:hasFacet": [
                 {
@@ -28,11 +28,11 @@
             ]
         },
         {
-            "@id": "kb:application1-ed4caa32-84c8-4813-b21d-f350e47cba7c",
+            "@id": "kb:application-ed4caa32-84c8-4813-b21d-f350e47cba7c",
             "@type": "uco-observable:Application"
         },
         {
-            "@id": "kb:application2-db5e8cbe-70e7-4dff-b981-2c5751b7923c",
+            "@id": "kb:application-db5e8cbe-70e7-4dff-b981-2c5751b7923c",
             "@type": "uco-observable:Application"
         },
         {
@@ -46,49 +46,49 @@
             "uco-core:name": "Google"
         },
         {
-            "@id": "kb:associated-account1-40d3bfa5-b808-4cf3-8f3e-4c8ea2d79686",
+            "@id": "kb:associated-account-40d3bfa5-b808-4cf3-8f3e-4c8ea2d79686",
             "@type": "uco-core:Relationship",
             "uco-core:source": {
-                "@id": "kb:actor1-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
+                "@id": "kb:actor-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:facebook_account1-c188af2d-9651-44a8-8d4c-07a1f5f1aa20"
+                    "@id": "kb:facebook_account-c188af2d-9651-44a8-8d4c-07a1f5f1aa20"
                 }
             ],
             "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:associated-account2-6620a818-7584-4760-a2cf-ff91aa742205",
+            "@id": "kb:associated-account-6620a818-7584-4760-a2cf-ff91aa742205",
             "@type": "uco-core:Relationship",
             "uco-core:source": {
-                "@id": "kb:actor1-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
+                "@id": "kb:actor-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:google_account1-f514a133-bca6-488c-a0a3-44c40f9ac766"
+                    "@id": "kb:google_account-f514a133-bca6-488c-a0a3-44c40f9ac766"
                 }
             ],
             "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:associated-account3-db2cb91c-c31d-496e-9802-bb15f24aa8c5",
+            "@id": "kb:associated-account-db2cb91c-c31d-496e-9802-bb15f24aa8c5",
             "@type": "uco-core:Relationship",
             "uco-core:source": {
-                "@id": "kb:actor1-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
+                "@id": "kb:actor-0058fc60-4b1b-4ad4-ba7e-231d00d40973"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:email_account1-e798e18c-0bef-4883-83df-e2710c4bc7e4"
+                    "@id": "kb:email_account-e798e18c-0bef-4883-83df-e2710c4bc7e4"
                 }
             ],
             "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:facebook_account1-c188af2d-9651-44a8-8d4c-07a1f5f1aa20",
+            "@id": "kb:facebook_account-c188af2d-9651-44a8-8d4c-07a1f5f1aa20",
             "@type": "uco-observable:DigitalAccount",
             "uco-core:hasFacet": [
                 {
@@ -122,7 +122,7 @@
                 {
                     "@type": "uco-observable:ApplicationAccountFacet",
                     "uco-observable:application": {
-                        "@id": "kb:application1-ed4caa32-84c8-4813-b21d-f350e47cba7c"
+                        "@id": "kb:application-ed4caa32-84c8-4813-b21d-f350e47cba7c"
                     }
                 },
                 {
@@ -140,22 +140,22 @@
             ]
         },
         {
-            "@id": "kb:associated-account4-419252da-6d0b-4f93-b070-75b9a5bc1cc2",
+            "@id": "kb:associated-account-419252da-6d0b-4f93-b070-75b9a5bc1cc2",
             "@type": "uco-core:Relationship",
             "rdfs:comment": "It is possible isDirectional should be false.  This is being tracked in UCO OC-135.",
             "uco-core:source": {
-                "@id": "kb:facebook_account1-c188af2d-9651-44a8-8d4c-07a1f5f1aa20"
+                "@id": "kb:facebook_account-c188af2d-9651-44a8-8d4c-07a1f5f1aa20"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:email_account1-e798e18c-0bef-4883-83df-e2710c4bc7e4"
+                    "@id": "kb:email_account-e798e18c-0bef-4883-83df-e2710c4bc7e4"
                 }
             ],
             "uco-core:kindOfRelationship": "Associated_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:google_account1-f514a133-bca6-488c-a0a3-44c40f9ac766",
+            "@id": "kb:google_account-f514a133-bca6-488c-a0a3-44c40f9ac766",
             "@type": "uco-observable:DigitalAccount",
             "uco-core:hasFacet": [
                 {
@@ -196,7 +196,7 @@
                 {
                     "@type": "uco-observable:ApplicationAccountFacet",
                     "uco-observable:application": {
-                        "@id": "kb:application2-db5e8cbe-70e7-4dff-b981-2c5751b7923c"
+                        "@id": "kb:application-db5e8cbe-70e7-4dff-b981-2c5751b7923c"
                     }
                 },
                 {
@@ -214,34 +214,34 @@
             ]
         },
         {
-            "@id": "kb:associated-account5-8222be1c-1e4a-4c1d-a631-bb3aa9743971",
+            "@id": "kb:associated-account-8222be1c-1e4a-4c1d-a631-bb3aa9743971",
             "@type": "uco-observable:ObservableRelationship",
             "rdfs:comment": "It is possible isDirectional should be false.  This is being tracked in UCO OC-135.",
             "uco-core:source": {
-                "@id": "kb:google_account1-f514a133-bca6-488c-a0a3-44c40f9ac766"
+                "@id": "kb:google_account-f514a133-bca6-488c-a0a3-44c40f9ac766"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:email_account1-e798e18c-0bef-4883-83df-e2710c4bc7e4"
+                    "@id": "kb:email_account-e798e18c-0bef-4883-83df-e2710c4bc7e4"
                 }
             ],
             "uco-core:kindOfRelationship": "Associated_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:email_account1-e798e18c-0bef-4883-83df-e2710c4bc7e4",
+            "@id": "kb:email_account-e798e18c-0bef-4883-83df-e2710c4bc7e4",
             "@type": "uco-observable:EmailAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:EmailAccountFacet",
                     "uco-observable:emailAddress": {
-                        "@id": "kb:email-address1-eeb346b0-470d-402b-b9ce-17134b1c572e"
+                        "@id": "kb:email-address-eeb346b0-470d-402b-b9ce-17134b1c572e"
                     }
                 }
             ]
         },
         {
-            "@id": "kb:email-address1-eeb346b0-470d-402b-b9ce-17134b1c572e",
+            "@id": "kb:email-address-eeb346b0-470d-402b-b9ce-17134b1c572e",
             "@type": "uco-observable:EmailAddress",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/bulk_extractor_forensic_path/bulk_extractor_forensic_path.json
+++ b/examples/illustrations/bulk_extractor_forensic_path/bulk_extractor_forensic_path.json
@@ -11,7 +11,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:extracted_email_address0-8a042a47-e34b-46e3-b5a2-0fac4fd66aa7",
+            "@id": "kb:extracted_email_address-8a042a47-e34b-46e3-b5a2-0fac4fd66aa7",
             "@type": "uco-observable:EmailAddress",
             "uco-core:hasFacet": [
                 {
@@ -39,13 +39,13 @@
             ]
         },
         {
-            "@id": "kb:relationship0-c8007a4a-46b3-4fbb-8b67-7a14b9e65694",
+            "@id": "kb:relationship-c8007a4a-46b3-4fbb-8b67-7a14b9e65694",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:extracted_email_address0-8a042a47-e34b-46e3-b5a2-0fac4fd66aa7"
+                "@id": "kb:extracted_email_address-8a042a47-e34b-46e3-b5a2-0fac4fd66aa7"
             },
             "uco-core:target": {
-                "@id": "kb:decompressed_gzip0-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
+                "@id": "kb:decompressed_gzip-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -58,7 +58,7 @@
             ]
         },
         {
-            "@id": "kb:extracted_email_address1-416ecb32-ecb1-4e23-a5b4-836c07a1de4e",
+            "@id": "kb:extracted_email_address-416ecb32-ecb1-4e23-a5b4-836c07a1de4e",
             "@type": "uco-observable:EmailAddress",
             "uco-core:hasFacet": [
                 {
@@ -86,13 +86,13 @@
             ]
         },
         {
-            "@id": "kb:relationship1-21bf5cd2-2365-420d-8175-a87fd722e790",
+            "@id": "kb:relationship-21bf5cd2-2365-420d-8175-a87fd722e790",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:extracted_email_address1-416ecb32-ecb1-4e23-a5b4-836c07a1de4e"
+                "@id": "kb:extracted_email_address-416ecb32-ecb1-4e23-a5b4-836c07a1de4e"
             },
             "uco-core:target": {
-                "@id": "kb:decompressed_gzip0-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
+                "@id": "kb:decompressed_gzip-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -105,7 +105,7 @@
             ]
         },
         {
-            "@id": "kb:decompressed_gzip0-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b",
+            "@id": "kb:decompressed_gzip-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b",
             "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
@@ -134,13 +134,13 @@
             ]
         },
         {
-            "@id": "kb:relationship3-a99e82ff-3908-41ea-b5db-71858d651476",
+            "@id": "kb:relationship-a99e82ff-3908-41ea-b5db-71858d651476",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:decompressed_gzip0-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
+                "@id": "kb:decompressed_gzip-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
             },
             "uco-core:target": {
-                "@id": "kb:compressed_gzip0-56ce1a82-7965-4a50-8feb-7524e03fba04"
+                "@id": "kb:compressed_gzip-56ce1a82-7965-4a50-8feb-7524e03fba04"
             },
             "uco-core:kindOfRelationship": "Decompressed_From",
             "uco-core:isDirectional": true,
@@ -152,7 +152,7 @@
             ]
         },
         {
-            "@id": "kb:compressed_gzip0-56ce1a82-7965-4a50-8feb-7524e03fba04",
+            "@id": "kb:compressed_gzip-56ce1a82-7965-4a50-8feb-7524e03fba04",
             "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
@@ -176,13 +176,13 @@
             ]
         },
         {
-            "@id": "kb:relationship4-58b547f5-65a5-4275-84d7-32a234f4aba0",
+            "@id": "kb:relationship-58b547f5-65a5-4275-84d7-32a234f4aba0",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:compressed_gzip0-56ce1a82-7965-4a50-8feb-7524e03fba04"
+                "@id": "kb:compressed_gzip-56ce1a82-7965-4a50-8feb-7524e03fba04"
             },
             "uco-core:target": {
-                "@id": "kb:decompressed_gzip1-93aef5ce-40a5-4bd4-8a4f-56f885d27695"
+                "@id": "kb:decompressed_gzip-93aef5ce-40a5-4bd4-8a4f-56f885d27695"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -195,7 +195,7 @@
             ]
         },
         {
-            "@id": "kb:decompressed_gzip1-93aef5ce-40a5-4bd4-8a4f-56f885d27695",
+            "@id": "kb:decompressed_gzip-93aef5ce-40a5-4bd4-8a4f-56f885d27695",
             "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
@@ -219,13 +219,13 @@
             ]
         },
         {
-            "@id": "kb:relationship5-c128681a-49ab-4b98-8535-e338132a795d",
+            "@id": "kb:relationship-c128681a-49ab-4b98-8535-e338132a795d",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:decompressed_gzip1-93aef5ce-40a5-4bd4-8a4f-56f885d27695"
+                "@id": "kb:decompressed_gzip-93aef5ce-40a5-4bd4-8a4f-56f885d27695"
             },
             "uco-core:target": {
-                "@id": "kb:compressed_gzip1-e17babc0-dabb-45d1-8202-0f02518c2a89"
+                "@id": "kb:compressed_gzip-e17babc0-dabb-45d1-8202-0f02518c2a89"
             },
             "uco-core:kindOfRelationship": "Decompressed_From",
             "uco-core:isDirectional": true,
@@ -237,7 +237,7 @@
             ]
         },
         {
-            "@id": "kb:compressed_gzip1-e17babc0-dabb-45d1-8202-0f02518c2a89",
+            "@id": "kb:compressed_gzip-e17babc0-dabb-45d1-8202-0f02518c2a89",
             "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
@@ -261,10 +261,10 @@
             ]
         },
         {
-            "@id": "kb:relationship6-4b3f030f-c214-48a8-9832-c302994d1874",
+            "@id": "kb:relationship-4b3f030f-c214-48a8-9832-c302994d1874",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:compressed_gzip1-e17babc0-dabb-45d1-8202-0f02518c2a89"
+                "@id": "kb:compressed_gzip-e17babc0-dabb-45d1-8202-0f02518c2a89"
             },
             "uco-core:target": {
                 "@id": "kb:disk_image-f654431a-ee73-4c9f-8ebb-e689df534f6c"

--- a/examples/illustrations/bulk_extractor_forensic_path/bulk_extractor_forensic_path.json
+++ b/examples/illustrations/bulk_extractor_forensic_path/bulk_extractor_forensic_path.json
@@ -11,7 +11,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:extracted_email_address0",
+            "@id": "kb:extracted_email_address0-8a042a47-e34b-46e3-b5a2-0fac4fd66aa7",
             "@type": "uco-observable:EmailAddress",
             "uco-core:hasFacet": [
                 {
@@ -39,13 +39,13 @@
             ]
         },
         {
-            "@id": "kb:relationship0",
+            "@id": "kb:relationship0-c8007a4a-46b3-4fbb-8b67-7a14b9e65694",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:extracted_email_address0"
+                "@id": "kb:extracted_email_address0-8a042a47-e34b-46e3-b5a2-0fac4fd66aa7"
             },
             "uco-core:target": {
-                "@id": "kb:decompressed_gzip0"
+                "@id": "kb:decompressed_gzip0-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -58,7 +58,7 @@
             ]
         },
         {
-            "@id": "kb:extracted_email_address1",
+            "@id": "kb:extracted_email_address1-416ecb32-ecb1-4e23-a5b4-836c07a1de4e",
             "@type": "uco-observable:EmailAddress",
             "uco-core:hasFacet": [
                 {
@@ -86,13 +86,13 @@
             ]
         },
         {
-            "@id": "kb:relationship1",
+            "@id": "kb:relationship1-21bf5cd2-2365-420d-8175-a87fd722e790",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:extracted_email_address1"
+                "@id": "kb:extracted_email_address1-416ecb32-ecb1-4e23-a5b4-836c07a1de4e"
             },
             "uco-core:target": {
-                "@id": "kb:decompressed_gzip0"
+                "@id": "kb:decompressed_gzip0-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -105,7 +105,7 @@
             ]
         },
         {
-            "@id": "kb:decompressed_gzip0",
+            "@id": "kb:decompressed_gzip0-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b",
             "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
@@ -134,13 +134,13 @@
             ]
         },
         {
-            "@id": "kb:relationship3",
+            "@id": "kb:relationship3-a99e82ff-3908-41ea-b5db-71858d651476",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:decompressed_gzip0"
+                "@id": "kb:decompressed_gzip0-95bfe9c0-1473-41e0-a2b4-22dd2d28bd8b"
             },
             "uco-core:target": {
-                "@id": "kb:compressed_gzip0"
+                "@id": "kb:compressed_gzip0-56ce1a82-7965-4a50-8feb-7524e03fba04"
             },
             "uco-core:kindOfRelationship": "Decompressed_From",
             "uco-core:isDirectional": true,
@@ -152,7 +152,7 @@
             ]
         },
         {
-            "@id": "kb:compressed_gzip0",
+            "@id": "kb:compressed_gzip0-56ce1a82-7965-4a50-8feb-7524e03fba04",
             "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
@@ -176,13 +176,13 @@
             ]
         },
         {
-            "@id": "kb:relationship4",
+            "@id": "kb:relationship4-58b547f5-65a5-4275-84d7-32a234f4aba0",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:compressed_gzip0"
+                "@id": "kb:compressed_gzip0-56ce1a82-7965-4a50-8feb-7524e03fba04"
             },
             "uco-core:target": {
-                "@id": "kb:decompressed_gzip1"
+                "@id": "kb:decompressed_gzip1-93aef5ce-40a5-4bd4-8a4f-56f885d27695"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -195,7 +195,7 @@
             ]
         },
         {
-            "@id": "kb:decompressed_gzip1",
+            "@id": "kb:decompressed_gzip1-93aef5ce-40a5-4bd4-8a4f-56f885d27695",
             "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
@@ -219,13 +219,13 @@
             ]
         },
         {
-            "@id": "kb:relationship5",
+            "@id": "kb:relationship5-c128681a-49ab-4b98-8535-e338132a795d",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:decompressed_gzip1"
+                "@id": "kb:decompressed_gzip1-93aef5ce-40a5-4bd4-8a4f-56f885d27695"
             },
             "uco-core:target": {
-                "@id": "kb:compressed_gzip1"
+                "@id": "kb:compressed_gzip1-e17babc0-dabb-45d1-8202-0f02518c2a89"
             },
             "uco-core:kindOfRelationship": "Decompressed_From",
             "uco-core:isDirectional": true,
@@ -237,7 +237,7 @@
             ]
         },
         {
-            "@id": "kb:compressed_gzip1",
+            "@id": "kb:compressed_gzip1-e17babc0-dabb-45d1-8202-0f02518c2a89",
             "@type": "uco-observable:ContentData",
             "uco-core:hasFacet": [
                 {
@@ -261,13 +261,13 @@
             ]
         },
         {
-            "@id": "kb:relationship6",
+            "@id": "kb:relationship6-4b3f030f-c214-48a8-9832-c302994d1874",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:compressed_gzip1"
+                "@id": "kb:compressed_gzip1-e17babc0-dabb-45d1-8202-0f02518c2a89"
             },
             "uco-core:target": {
-                "@id": "kb:disk_image"
+                "@id": "kb:disk_image-f654431a-ee73-4c9f-8ebb-e689df534f6c"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -280,7 +280,7 @@
             ]
         },
         {
-            "@id": "kb:disk_image",
+            "@id": "kb:disk_image-f654431a-ee73-4c9f-8ebb-e689df534f6c",
             "@type": [
                 "uco-observable:File",
                 "uco-observable:Image"

--- a/examples/illustrations/call_log/call_log.json
+++ b/examples/illustrations/call_log/call_log.json
@@ -10,19 +10,19 @@
     },
     "@graph": [
         {
-            "@id": "kb:ATT-466a0ea8-b22f-4175-8119-846bec8f7831",
+            "@id": "kb:att-466a0ea8-b22f-4175-8119-846bec8f7831",
             "@type": "uco-identity:Organization"
         },
         {
-            "@id": "kb:Sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202",
+            "@id": "kb:sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202",
             "@type": "uco-identity:Organization"
         },
         {
-            "@id": "kb:Verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12",
+            "@id": "kb:verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12",
             "@type": "uco-identity:Organization"
         },
         {
-            "@id": "kb:Zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b",
+            "@id": "kb:zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b",
             "@type": "uco-identity:Organization"
         },
         {
@@ -44,7 +44,7 @@
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:ATT-466a0ea8-b22f-4175-8119-846bec8f7831"
+                        "@id": "kb:att-466a0ea8-b22f-4175-8119-846bec8f7831"
                     },
                     "uco-observable:isActive": true
                 },
@@ -61,7 +61,7 @@
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:Sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202"
+                        "@id": "kb:sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202"
                     },
                     "uco-observable:isActive": true
                 },
@@ -78,7 +78,7 @@
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:Verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12"
+                        "@id": "kb:verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12"
                     },
                     "uco-observable:isActive": true
                 },
@@ -95,7 +95,7 @@
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:Zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b"
+                        "@id": "kb:zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b"
                     },
                     "uco-observable:isActive": true
                 },

--- a/examples/illustrations/call_log/call_log.json
+++ b/examples/illustrations/call_log/call_log.json
@@ -38,7 +38,7 @@
             "@type": "uco-observable:Application"
         },
         {
-            "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba",
+            "@id": "kb:phone_account-4e172ed5-7b58-4903-96fe-4558f46820ba",
             "@type": "uco-observable:PhoneAccount",
             "uco-core:hasFacet": [
                 {
@@ -55,7 +55,7 @@
             ]
         },
         {
-            "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93",
+            "@id": "kb:phone_account-86bdc508-1f64-4df3-bc8f-0136976c2e93",
             "@type": "uco-observable:PhoneAccount",
             "uco-core:hasFacet": [
                 {
@@ -72,7 +72,7 @@
             ]
         },
         {
-            "@id": "kb:phone_account3-19db8820-3d40-4b38-84cf-abbb26c95128",
+            "@id": "kb:phone_account-19db8820-3d40-4b38-84cf-abbb26c95128",
             "@type": "uco-observable:PhoneAccount",
             "uco-core:hasFacet": [
                 {
@@ -89,7 +89,7 @@
             ]
         },
         {
-            "@id": "kb:bridge_account1-2ee6c2f5-11dd-42f4-9345-cdefc1e24889",
+            "@id": "kb:bridge_account-2ee6c2f5-11dd-42f4-9345-cdefc1e24889",
             "@type": "uco-observable:PhoneAccount",
             "uco-core:hasFacet": [
                 {
@@ -106,7 +106,7 @@
             ]
         },
         {
-            "@id": "kb:phone_call1-edacc7ec-4e8e-4de4-ad83-10a892cd3855",
+            "@id": "kb:phone_call-edacc7ec-4e8e-4de4-ad83-10a892cd3855",
             "@type": "uco-observable:Call",
             "uco-core:description": "An example of a two-party, one-way phone call that has clear directionality between a caller (from) and receiver (to).",
             "uco-core:hasFacet": [
@@ -125,17 +125,17 @@
                         "@value": "2010-01-15T18:30:41.25Z"
                     },
                     "uco-observable:from": {
-                        "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba"
+                        "@id": "kb:phone_account-4e172ed5-7b58-4903-96fe-4558f46820ba"
                     },
                     "uco-observable:to": {
-                        "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93"
+                        "@id": "kb:phone_account-86bdc508-1f64-4df3-bc8f-0136976c2e93"
                     },
                     "uco-observable:duration": 1862
                 }
             ]
         },
         {
-            "@id": "kb:non-directional-phone-call-1-d3d321f3-0c47-4ca6-90f7-18697160dcd2",
+            "@id": "kb:non-directional-phone-call-d3d321f3-0c47-4ca6-90f7-18697160dcd2",
             "@type": "uco-observable:Call",
             "uco-core:description": "An example of a two-party, one-way phone call that has does not have clear directionality between a caller (from) and receiver (to).",
             "uco-core:hasFacet": [
@@ -155,10 +155,10 @@
                     },
                     "uco-observable:to": [
                         {
-                            "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba"
+                            "@id": "kb:phone_account-4e172ed5-7b58-4903-96fe-4558f46820ba"
                         },
                         {
-                            "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93"
+                            "@id": "kb:phone_account-86bdc508-1f64-4df3-bc8f-0136976c2e93"
                         }
                     ],
                     "uco-observable:duration": 1862
@@ -166,7 +166,7 @@
             ]
         },
         {
-            "@id": "kb:multi-participant-phone-call-1-ce14cf4d-2530-4f8f-9cb6-06f851d1691b",
+            "@id": "kb:multi-participant-phone-call-ce14cf4d-2530-4f8f-9cb6-06f851d1691b",
             "@type": "uco-observable:Call",
             "uco-core:description": "An example of a three-way call phone call that has clear directionality between a caller (from) and two receivers (to).",
             "uco-core:hasFacet": [
@@ -185,14 +185,14 @@
                         "@value": "2010-01-15T18:30:41.25Z"
                     },
                     "uco-observable:from": {
-                        "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba"
+                        "@id": "kb:phone_account-4e172ed5-7b58-4903-96fe-4558f46820ba"
                     },
                     "uco-observable:to": [
                         {
-                            "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93"
+                            "@id": "kb:phone_account-86bdc508-1f64-4df3-bc8f-0136976c2e93"
                         },
                         {
-                            "@id": "kb:phone_account3-19db8820-3d40-4b38-84cf-abbb26c95128"
+                            "@id": "kb:phone_account-19db8820-3d40-4b38-84cf-abbb26c95128"
                         }
                     ],
                     "uco-observable:duration": 1862
@@ -200,7 +200,7 @@
             ]
         },
         {
-            "@id": "kb:conference-bridge-phone-call-1-b3030d8b-ec64-4d88-b136-d4705f657e37",
+            "@id": "kb:conference-bridge-phone-call-b3030d8b-ec64-4d88-b136-d4705f657e37",
             "@type": "uco-observable:Call",
             "uco-core:description": "An example of a conference bridge phone call that does not have clear directionality between a caller (from) and receivers (to).",
             "uco-core:hasFacet": [
@@ -220,16 +220,16 @@
                     },
                     "uco-observable:to": [
                         {
-                            "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba"
+                            "@id": "kb:phone_account-4e172ed5-7b58-4903-96fe-4558f46820ba"
                         },
                         {
-                            "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93"
+                            "@id": "kb:phone_account-86bdc508-1f64-4df3-bc8f-0136976c2e93"
                         },
                         {
-                            "@id": "kb:phone_account3-19db8820-3d40-4b38-84cf-abbb26c95128"
+                            "@id": "kb:phone_account-19db8820-3d40-4b38-84cf-abbb26c95128"
                         },
                         {
-                            "@id": "kb:bridge_account1-2ee6c2f5-11dd-42f4-9345-cdefc1e24889"
+                            "@id": "kb:bridge_account-2ee6c2f5-11dd-42f4-9345-cdefc1e24889"
                         }
                     ],
                     "uco-observable:duration": 1862

--- a/examples/illustrations/call_log/call_log.json
+++ b/examples/illustrations/call_log/call_log.json
@@ -10,19 +10,19 @@
     },
     "@graph": [
         {
-            "@id": "kb:ATT",
+            "@id": "kb:ATT-466a0ea8-b22f-4175-8119-846bec8f7831",
             "@type": "uco-identity:Organization"
         },
         {
-            "@id": "kb:Sprint",
+            "@id": "kb:Sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202",
             "@type": "uco-identity:Organization"
         },
         {
-            "@id": "kb:Verizon",
+            "@id": "kb:Verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12",
             "@type": "uco-identity:Organization"
         },
         {
-            "@id": "kb:Zoom",
+            "@id": "kb:Zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b",
             "@type": "uco-identity:Organization"
         },
         {
@@ -38,13 +38,13 @@
             "@type": "uco-observable:Application"
         },
         {
-            "@id": "kb:phone_account1",
+            "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba",
             "@type": "uco-observable:PhoneAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:ATT"
+                        "@id": "kb:ATT-466a0ea8-b22f-4175-8119-846bec8f7831"
                     },
                     "uco-observable:isActive": true
                 },
@@ -55,13 +55,13 @@
             ]
         },
         {
-            "@id": "kb:phone_account2",
+            "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93",
             "@type": "uco-observable:PhoneAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:Sprint"
+                        "@id": "kb:Sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202"
                     },
                     "uco-observable:isActive": true
                 },
@@ -72,13 +72,13 @@
             ]
         },
         {
-            "@id": "kb:phone_account3",
+            "@id": "kb:phone_account3-19db8820-3d40-4b38-84cf-abbb26c95128",
             "@type": "uco-observable:PhoneAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:Verizon"
+                        "@id": "kb:Verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12"
                     },
                     "uco-observable:isActive": true
                 },
@@ -89,13 +89,13 @@
             ]
         },
         {
-            "@id": "kb:bridge_account1",
+            "@id": "kb:bridge_account1-2ee6c2f5-11dd-42f4-9345-cdefc1e24889",
             "@type": "uco-observable:PhoneAccount",
             "uco-core:hasFacet": [
                 {
                     "@type": "uco-observable:AccountFacet",
                     "uco-observable:accountIssuer": {
-                        "@id": "kb:Zoom"
+                        "@id": "kb:Zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b"
                     },
                     "uco-observable:isActive": true
                 },
@@ -106,7 +106,7 @@
             ]
         },
         {
-            "@id": "kb:phone_call1",
+            "@id": "kb:phone_call1-edacc7ec-4e8e-4de4-ad83-10a892cd3855",
             "@type": "uco-observable:Call",
             "uco-core:description": "An example of a two-party, one-way phone call that has clear directionality between a caller (from) and receiver (to).",
             "uco-core:hasFacet": [
@@ -125,17 +125,17 @@
                         "@value": "2010-01-15T18:30:41.25Z"
                     },
                     "uco-observable:from": {
-                        "@id": "kb:phone_account1"
+                        "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba"
                     },
                     "uco-observable:to": {
-                        "@id": "kb:phone_account2"
+                        "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93"
                     },
                     "uco-observable:duration": 1862
                 }
             ]
         },
         {
-            "@id": "kb:non-directional-phone-call-1",
+            "@id": "kb:non-directional-phone-call-1-d3d321f3-0c47-4ca6-90f7-18697160dcd2",
             "@type": "uco-observable:Call",
             "uco-core:description": "An example of a two-party, one-way phone call that has does not have clear directionality between a caller (from) and receiver (to).",
             "uco-core:hasFacet": [
@@ -155,10 +155,10 @@
                     },
                     "uco-observable:to": [
                         {
-                            "@id": "kb:phone_account1"
+                            "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba"
                         },
                         {
-                            "@id": "kb:phone_account2"
+                            "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93"
                         }
                     ],
                     "uco-observable:duration": 1862
@@ -166,7 +166,7 @@
             ]
         },
         {
-            "@id": "kb:multi-participant-phone-call-1",
+            "@id": "kb:multi-participant-phone-call-1-ce14cf4d-2530-4f8f-9cb6-06f851d1691b",
             "@type": "uco-observable:Call",
             "uco-core:description": "An example of a three-way call phone call that has clear directionality between a caller (from) and two receivers (to).",
             "uco-core:hasFacet": [
@@ -185,14 +185,14 @@
                         "@value": "2010-01-15T18:30:41.25Z"
                     },
                     "uco-observable:from": {
-                        "@id": "kb:phone_account1"
+                        "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba"
                     },
                     "uco-observable:to": [
                         {
-                            "@id": "kb:phone_account2"
+                            "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93"
                         },
                         {
-                            "@id": "kb:phone_account3"
+                            "@id": "kb:phone_account3-19db8820-3d40-4b38-84cf-abbb26c95128"
                         }
                     ],
                     "uco-observable:duration": 1862
@@ -200,7 +200,7 @@
             ]
         },
         {
-            "@id": "kb:conference-bridge-phone-call-1",
+            "@id": "kb:conference-bridge-phone-call-1-b3030d8b-ec64-4d88-b136-d4705f657e37",
             "@type": "uco-observable:Call",
             "uco-core:description": "An example of a conference bridge phone call that does not have clear directionality between a caller (from) and receivers (to).",
             "uco-core:hasFacet": [
@@ -220,16 +220,16 @@
                     },
                     "uco-observable:to": [
                         {
-                            "@id": "kb:phone_account1"
+                            "@id": "kb:phone_account1-4e172ed5-7b58-4903-96fe-4558f46820ba"
                         },
                         {
-                            "@id": "kb:phone_account2"
+                            "@id": "kb:phone_account2-86bdc508-1f64-4df3-bc8f-0136976c2e93"
                         },
                         {
-                            "@id": "kb:phone_account3"
+                            "@id": "kb:phone_account3-19db8820-3d40-4b38-84cf-abbb26c95128"
                         },
                         {
-                            "@id": "kb:bridge_account1"
+                            "@id": "kb:bridge_account1-2ee6c2f5-11dd-42f4-9345-cdefc1e24889"
                         }
                     ],
                     "uco-observable:duration": 1862

--- a/examples/illustrations/call_log/call_log_validation-develop.ttl
+++ b/examples/illustrations/call_log/call_log_validation-develop.ttl
@@ -13,10 +13,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/ATT> ;
+				observable:accountIssuer <http://example.org/kb/att-466a0ea8-b22f-4175-8119-846bec8f7831> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:ATT ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:att-466a0ea8-b22f-4175-8119-846bec8f7831 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -32,10 +32,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Sprint> ;
+				observable:accountIssuer <http://example.org/kb/sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Sprint ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -51,10 +51,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Verizon> ;
+				observable:accountIssuer <http://example.org/kb/verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Verizon ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -70,10 +70,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Zoom> ;
+				observable:accountIssuer <http://example.org/kb/zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Zoom ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;

--- a/examples/illustrations/call_log/call_log_validation-unstable.ttl
+++ b/examples/illustrations/call_log/call_log_validation-unstable.ttl
@@ -13,10 +13,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/ATT> ;
+				observable:accountIssuer <http://example.org/kb/att-466a0ea8-b22f-4175-8119-846bec8f7831> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:ATT ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:att-466a0ea8-b22f-4175-8119-846bec8f7831 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -32,10 +32,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Sprint> ;
+				observable:accountIssuer <http://example.org/kb/sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Sprint ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -51,10 +51,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Verizon> ;
+				observable:accountIssuer <http://example.org/kb/verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Verizon ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -70,10 +70,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Zoom> ;
+				observable:accountIssuer <http://example.org/kb/zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Zoom ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;

--- a/examples/illustrations/call_log/call_log_validation.ttl
+++ b/examples/illustrations/call_log/call_log_validation.ttl
@@ -13,10 +13,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/ATT> ;
+				observable:accountIssuer <http://example.org/kb/att-466a0ea8-b22f-4175-8119-846bec8f7831> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:ATT ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:att-466a0ea8-b22f-4175-8119-846bec8f7831 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -32,10 +32,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Sprint> ;
+				observable:accountIssuer <http://example.org/kb/sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Sprint ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:sprint-68503a2e-6ec3-422a-8ef4-9f57f2aad202 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -51,10 +51,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Verizon> ;
+				observable:accountIssuer <http://example.org/kb/verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Verizon ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:verizon-47a7bc5c-f4a7-4fe3-a700-82bcfaf07a12 ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
@@ -70,10 +70,10 @@
 			a sh:ValidationResult ;
 			sh:focusNode [
 				a observable:AccountFacet ;
-				observable:accountIssuer <http://example.org/kb/Zoom> ;
+				observable:accountIssuer <http://example.org/kb/zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b> ;
 				observable:isActive "true"^^xsd:boolean ;
 			] ;
-			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:Zoom ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
+			sh:resultMessage 'Less than 1 values on [ rdf:type uco-observable:AccountFacet ; uco-observable:accountIssuer kb:zoom-b5a12ff2-91ac-42d1-9741-7db20e50bc0b ; uco-observable:isActive Literal("true" = True, datatype=xsd:boolean) ]->observable:accountIdentifier' ;
 			sh:resultPath observable:accountIdentifier ;
 			sh:resultSeverity sh:Violation ;
 			sh:sourceConstraintComponent sh:MinCountConstraintComponent ;

--- a/examples/illustrations/cell_site/cell_site.json
+++ b/examples/illustrations/cell_site/cell_site.json
@@ -124,7 +124,7 @@
                 {
                     "@type": "drafting:CapturedTelecommunicationsInformationFacet",
                     "drafting:captureCellSite": {
-                        "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"
+                        "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
                     },
                     "drafting:interceptedCallState": "idle",
                     "observable:endTime": {
@@ -241,7 +241,7 @@
                 "sosa:Observation"
             ],
             "sosa:hasFeatureOfInterest": {
-                "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"
+                "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
             },
             "sosa:resultTime": {
                 "@type": "xsd:dateTime",
@@ -259,7 +259,7 @@
                 "sosa:Observation"
             ],
             "sosa:hasFeatureOfInterest": {
-                "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"
+                "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
             },
             "sosa:hasResult": {
                 "@id": "kb:location-403d0147-f7ff-4f3e-aa43-19a988e8a3ee"
@@ -282,14 +282,14 @@
             "uco-core:isDirectional": true,
             "uco-core:kindOfRelationship": "Located_At",
             "uco-core:source": {
-                "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"
+                "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
             },
             "uco-core:target": {
                 "@id": "kb:location-403d0147-f7ff-4f3e-aa43-19a988e8a3ee"
             }
         },
         {
-            "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399",
+            "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26",
             "@type": "drafting:CellSite",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/cell_site/cell_site.json
+++ b/examples/illustrations/cell_site/cell_site.json
@@ -124,7 +124,7 @@
                 {
                     "@type": "drafting:CapturedTelecommunicationsInformationFacet",
                     "drafting:captureCellSite": {
-                        "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
+                        "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"
                     },
                     "drafting:interceptedCallState": "idle",
                     "observable:endTime": {
@@ -241,7 +241,7 @@
                 "sosa:Observation"
             ],
             "sosa:hasFeatureOfInterest": {
-                "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
+                "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"
             },
             "sosa:resultTime": {
                 "@type": "xsd:dateTime",
@@ -259,7 +259,7 @@
                 "sosa:Observation"
             ],
             "sosa:hasFeatureOfInterest": {
-                "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
+                "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"
             },
             "sosa:hasResult": {
                 "@id": "kb:location-403d0147-f7ff-4f3e-aa43-19a988e8a3ee"
@@ -282,14 +282,14 @@
             "uco-core:isDirectional": true,
             "uco-core:kindOfRelationship": "Located_At",
             "uco-core:source": {
-                "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
+                "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"
             },
             "uco-core:target": {
                 "@id": "kb:location-403d0147-f7ff-4f3e-aa43-19a988e8a3ee"
             }
         },
         {
-            "@id": "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26",
+            "@id": "urn:example:cell-site-kb:cell-cite-204-16-1014-13399",
             "@type": "drafting:CellSite",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/device/device.json
+++ b/examples/illustrations/device/device.json
@@ -22,10 +22,10 @@
             "uco-core:name": "Microsoft"
         },
         {
-            "@id": "kb:forensic_lab_computer1-a730c324-49e6-4b12-869e-6addd946545d",
+            "@id": "kb:forensic_lab_computer-a730c324-49e6-4b12-869e-6addd946545d",
             "@type": "uco-observable:Device",
             "location": {
-                "@id": "kb:forensic_lab1-2514fffb-affc-43be-a3bb-be1dd606eff0"
+                "@id": "kb:forensic_lab-2514fffb-affc-43be-a3bb-be1dd606eff0"
             },
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/device/device.json
+++ b/examples/illustrations/device/device.json
@@ -22,10 +22,10 @@
             "uco-core:name": "Microsoft"
         },
         {
-            "@id": "kb:forensic_lab_computer1-uuid",
+            "@id": "kb:forensic_lab_computer1-a730c324-49e6-4b12-869e-6addd946545d",
             "@type": "uco-observable:Device",
             "location": {
-                "@id": "kb:forensic_lab1-uuid"
+                "@id": "kb:forensic_lab1-2514fffb-affc-43be-a3bb-be1dd606eff0"
             },
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/exif_data/exif_data.json
+++ b/examples/illustrations/exif_data/exif_data.json
@@ -21,7 +21,7 @@
             "uco-core:name": "Canon"
         },
         {
-            "@id": "kb:camera1",
+            "@id": "kb:camera1-a59ca7f2-cf15-4800-9dd3-1a2df40c6f6e",
             "@type": "uco-observable:Device",
             "uco-core:hasFacet": [
                 {
@@ -36,13 +36,13 @@
             ]
         },
         {
-            "@id": "kb:relationship1",
+            "@id": "kb:relationship1-03f0f4a6-661a-46f8-a602-15d9d1b67f32",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:digital_photograph1"
+                "@id": "kb:digital_photograph1-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae"
             },
             "uco-core:target": {
-                "@id": "kb:device_partition3"
+                "@id": "kb:device_partition3-f1a14892-8179-48aa-a74b-e3e434a9c0c1"
             },
             "uco-core:isDirectional": true,
             "uco-core:kindOfRelationship": "Contained_Within",
@@ -54,7 +54,7 @@
             ]
         },
         {
-            "@id": "kb:digital_photograph1",
+            "@id": "kb:digital_photograph1-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae",
             "@type": "uco-observable:File",
             "uco-core:hasFacet": [
                 {
@@ -147,7 +147,7 @@
             ]
         },
         {
-            "@id": "kb:camera_action1",
+            "@id": "kb:camera_action1-7995f522-6388-463f-855e-e08130477744",
             "@type": "uco-action:Action",
             "uco-core:name": "photo_taken",
             "uco-action:startTime": {
@@ -155,43 +155,43 @@
                 "@value": "2010-01-15T17:59:43.25Z"
             },
             "uco-action:instrument": {
-                "@id": "kb:camera1"
+                "@id": "kb:camera1-a59ca7f2-cf15-4800-9dd3-1a2df40c6f6e"
             },
             "uco-action:result": [
                 {
-                    "@id": "kb:digital_photograph1"
+                    "@id": "kb:digital_photograph1-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae"
                 }
             ],
             "uco-action:location": {
-                "@id": "kb:location1"
+                "@id": "kb:location1-a81948a1-e395-416a-9322-5742866f7020"
             }
         },
         {
-            "@id": "kb:annotator_tool1",
+            "@id": "kb:annotator_tool1-ca41faa8-a59c-4321-b047-4d916f75b1e8",
             "@type": "uco-tool:AnalyticTool"
         },
         {
-            "@id": "kb:examiner1",
+            "@id": "kb:examiner1-88a08acc-dad2-4964-be3b-8b70e11a4f4d",
             "@type": "uco-identity:Person"
         },
         {
-            "@id": "kb:forensic_lab_computer1",
+            "@id": "kb:forensic_lab_computer1-4e95a8d3-066a-4600-8ad0-8b4d0241ce5c",
             "@type": "uco-observable:Device"
         },
         {
-            "@id": "kb:location1",
+            "@id": "kb:location1-a81948a1-e395-416a-9322-5742866f7020",
             "@type": "uco-location:Location"
         },
         {
-            "@id": "kb:device_partition3",
+            "@id": "kb:device_partition3-f1a14892-8179-48aa-a74b-e3e434a9c0c1",
             "@type": "uco-observable:DiskPartition"
         },
         {
-            "@id": "kb:forensic_lab1",
+            "@id": "kb:forensic_lab1-fae4ff1e-7d06-49da-9c89-da37ef612b25",
             "@type": "uco-location:Location"
         },
         {
-            "@id": "kb:annotation1",
+            "@id": "kb:annotation1-b8258799-b465-4182-904b-c0aa73a35b0b",
             "@type": "uco-core:Annotation",
             "uco-core:description": "Photo was taken by a Canon digital camera.",
             "uco-core:tag": [
@@ -200,11 +200,11 @@
                 "extracted"
             ],
             "uco-core:object": {
-                "@id": "kb:camera_action1"
+                "@id": "kb:camera_action1-7995f522-6388-463f-855e-e08130477744"
             }
         },
         {
-            "@id": "kb:forensic_action7",
+            "@id": "kb:forensic_action7-306e44f8-446d-4cff-a2fd-9e54affb1fa3",
             "@type": "case-investigation:InvestigativeAction",
             "uco-core:name": "annotated",
             "uco-action:startTime": {
@@ -216,21 +216,21 @@
                 "@value": "2010-01-15T18:59:43.25Z"
             },
             "uco-action:performer": {
-                "@id": "kb:examiner1"
+                "@id": "kb:examiner1-88a08acc-dad2-4964-be3b-8b70e11a4f4d"
             },
             "uco-action:instrument": {
-                "@id": "kb:annotator_tool1"
+                "@id": "kb:annotator_tool1-ca41faa8-a59c-4321-b047-4d916f75b1e8"
             },
             "uco-action:result": [
                 {
-                    "@id": "kb:annotation1"
+                    "@id": "kb:annotation1-b8258799-b465-4182-904b-c0aa73a35b0b"
                 }
             ],
             "uco-action:location": {
-                "@id": "kb:forensic_lab1"
+                "@id": "kb:forensic_lab1-fae4ff1e-7d06-49da-9c89-da37ef612b25"
             },
             "uco-action:environment": {
-                "@id": "kb:forensic_lab_computer1"
+                "@id": "kb:forensic_lab_computer1-4e95a8d3-066a-4600-8ad0-8b4d0241ce5c"
             }
         }
     ]

--- a/examples/illustrations/exif_data/exif_data.json
+++ b/examples/illustrations/exif_data/exif_data.json
@@ -21,7 +21,7 @@
             "uco-core:name": "Canon"
         },
         {
-            "@id": "kb:camera1-a59ca7f2-cf15-4800-9dd3-1a2df40c6f6e",
+            "@id": "kb:camera-a59ca7f2-cf15-4800-9dd3-1a2df40c6f6e",
             "@type": "uco-observable:Device",
             "uco-core:hasFacet": [
                 {
@@ -36,13 +36,13 @@
             ]
         },
         {
-            "@id": "kb:relationship1-03f0f4a6-661a-46f8-a602-15d9d1b67f32",
+            "@id": "kb:relationship-03f0f4a6-661a-46f8-a602-15d9d1b67f32",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:digital_photograph1-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae"
+                "@id": "kb:digital_photograph-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae"
             },
             "uco-core:target": {
-                "@id": "kb:device_partition3-f1a14892-8179-48aa-a74b-e3e434a9c0c1"
+                "@id": "kb:device_partition-f1a14892-8179-48aa-a74b-e3e434a9c0c1"
             },
             "uco-core:isDirectional": true,
             "uco-core:kindOfRelationship": "Contained_Within",
@@ -54,7 +54,7 @@
             ]
         },
         {
-            "@id": "kb:digital_photograph1-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae",
+            "@id": "kb:digital_photograph-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae",
             "@type": "uco-observable:File",
             "uco-core:hasFacet": [
                 {
@@ -147,7 +147,7 @@
             ]
         },
         {
-            "@id": "kb:camera_action1-7995f522-6388-463f-855e-e08130477744",
+            "@id": "kb:camera_action-7995f522-6388-463f-855e-e08130477744",
             "@type": "uco-action:Action",
             "uco-core:name": "photo_taken",
             "uco-action:startTime": {
@@ -155,43 +155,43 @@
                 "@value": "2010-01-15T17:59:43.25Z"
             },
             "uco-action:instrument": {
-                "@id": "kb:camera1-a59ca7f2-cf15-4800-9dd3-1a2df40c6f6e"
+                "@id": "kb:camera-a59ca7f2-cf15-4800-9dd3-1a2df40c6f6e"
             },
             "uco-action:result": [
                 {
-                    "@id": "kb:digital_photograph1-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae"
+                    "@id": "kb:digital_photograph-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae"
                 }
             ],
             "uco-action:location": {
-                "@id": "kb:location1-a81948a1-e395-416a-9322-5742866f7020"
+                "@id": "kb:location-a81948a1-e395-416a-9322-5742866f7020"
             }
         },
         {
-            "@id": "kb:annotator_tool1-ca41faa8-a59c-4321-b047-4d916f75b1e8",
+            "@id": "kb:annotator_tool-ca41faa8-a59c-4321-b047-4d916f75b1e8",
             "@type": "uco-tool:AnalyticTool"
         },
         {
-            "@id": "kb:examiner1-88a08acc-dad2-4964-be3b-8b70e11a4f4d",
+            "@id": "kb:examiner-88a08acc-dad2-4964-be3b-8b70e11a4f4d",
             "@type": "uco-identity:Person"
         },
         {
-            "@id": "kb:forensic_lab_computer1-4e95a8d3-066a-4600-8ad0-8b4d0241ce5c",
+            "@id": "kb:forensic_lab_computer-4e95a8d3-066a-4600-8ad0-8b4d0241ce5c",
             "@type": "uco-observable:Device"
         },
         {
-            "@id": "kb:location1-a81948a1-e395-416a-9322-5742866f7020",
+            "@id": "kb:location-a81948a1-e395-416a-9322-5742866f7020",
             "@type": "uco-location:Location"
         },
         {
-            "@id": "kb:device_partition3-f1a14892-8179-48aa-a74b-e3e434a9c0c1",
+            "@id": "kb:device_partition-f1a14892-8179-48aa-a74b-e3e434a9c0c1",
             "@type": "uco-observable:DiskPartition"
         },
         {
-            "@id": "kb:forensic_lab1-fae4ff1e-7d06-49da-9c89-da37ef612b25",
+            "@id": "kb:forensic_lab-fae4ff1e-7d06-49da-9c89-da37ef612b25",
             "@type": "uco-location:Location"
         },
         {
-            "@id": "kb:annotation1-b8258799-b465-4182-904b-c0aa73a35b0b",
+            "@id": "kb:annotation-b8258799-b465-4182-904b-c0aa73a35b0b",
             "@type": "uco-core:Annotation",
             "uco-core:description": "Photo was taken by a Canon digital camera.",
             "uco-core:tag": [
@@ -200,11 +200,11 @@
                 "extracted"
             ],
             "uco-core:object": {
-                "@id": "kb:camera_action1-7995f522-6388-463f-855e-e08130477744"
+                "@id": "kb:camera_action-7995f522-6388-463f-855e-e08130477744"
             }
         },
         {
-            "@id": "kb:forensic_action7-306e44f8-446d-4cff-a2fd-9e54affb1fa3",
+            "@id": "kb:forensic_action-306e44f8-446d-4cff-a2fd-9e54affb1fa3",
             "@type": "case-investigation:InvestigativeAction",
             "uco-core:name": "annotated",
             "uco-action:startTime": {
@@ -216,21 +216,21 @@
                 "@value": "2010-01-15T18:59:43.25Z"
             },
             "uco-action:performer": {
-                "@id": "kb:examiner1-88a08acc-dad2-4964-be3b-8b70e11a4f4d"
+                "@id": "kb:examiner-88a08acc-dad2-4964-be3b-8b70e11a4f4d"
             },
             "uco-action:instrument": {
-                "@id": "kb:annotator_tool1-ca41faa8-a59c-4321-b047-4d916f75b1e8"
+                "@id": "kb:annotator_tool-ca41faa8-a59c-4321-b047-4d916f75b1e8"
             },
             "uco-action:result": [
                 {
-                    "@id": "kb:annotation1-b8258799-b465-4182-904b-c0aa73a35b0b"
+                    "@id": "kb:annotation-b8258799-b465-4182-904b-c0aa73a35b0b"
                 }
             ],
             "uco-action:location": {
-                "@id": "kb:forensic_lab1-fae4ff1e-7d06-49da-9c89-da37ef612b25"
+                "@id": "kb:forensic_lab-fae4ff1e-7d06-49da-9c89-da37ef612b25"
             },
             "uco-action:environment": {
-                "@id": "kb:forensic_lab_computer1-4e95a8d3-066a-4600-8ad0-8b4d0241ce5c"
+                "@id": "kb:forensic_lab_computer-4e95a8d3-066a-4600-8ad0-8b4d0241ce5c"
             }
         }
     ]

--- a/examples/illustrations/exif_data/query-select-files.md
+++ b/examples/illustrations/exif_data/query-select-files.md
@@ -1,3 +1,3 @@
-|    | ?nFile                                    | ?lFileName   |
-|----|-------------------------------------------|--------------|
-|  0 | http://example.org/kb/digital_photograph1 | IMG_0123.jpg |
+|    | ?nFile                                                                        | ?lFileName   |
+|----|-------------------------------------------------------------------------------|--------------|
+|  0 | http://example.org/kb/digital_photograph-3a9be7ba-c2b6-4511-b9c4-fabb729bbcae | IMG_0123.jpg |

--- a/examples/illustrations/location/location.json
+++ b/examples/illustrations/location/location.json
@@ -11,7 +11,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:location1-4511219e-a924-4ba5-aee7-dfad5a2c9c05",
+            "@id": "kb:location-4511219e-a924-4ba5-aee7-dfad5a2c9c05",
             "@type": "uco-location:Location",
             "uco-core:hasFacet": [
                 {
@@ -32,7 +32,7 @@
             ]
         },
         {
-            "@id": "kb:location2-b579264d-6e30-4055-bf9b-72390364f224",
+            "@id": "kb:location-b579264d-6e30-4055-bf9b-72390364f224",
             "@type": "uco-location:Location",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/location/location.json
+++ b/examples/illustrations/location/location.json
@@ -11,7 +11,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:location1",
+            "@id": "kb:location1-4511219e-a924-4ba5-aee7-dfad5a2c9c05",
             "@type": "uco-location:Location",
             "uco-core:hasFacet": [
                 {
@@ -32,7 +32,7 @@
             ]
         },
         {
-            "@id": "kb:location2",
+            "@id": "kb:location2-b579264d-6e30-4055-bf9b-72390364f224",
             "@type": "uco-location:Location",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/mobile_device_and_sim_card/mobile_device_and_sim_card.json
+++ b/examples/illustrations/mobile_device_and_sim_card/mobile_device_and_sim_card.json
@@ -63,7 +63,7 @@
             "uco-core:name": "Apple"
         },
         {
-            "@id": "kb:trace-relationship1-44bc4b9d-680d-499f-9db1-80af07e11bdc",
+            "@id": "kb:trace-relationship-44bc4b9d-680d-499f-9db1-80af07e11bdc",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
                 "@id": "kb:sim-card-8b2024b5-1e73-405c-b89f-6e4be86692ef"
@@ -85,7 +85,7 @@
                     "uco-observable:ICCID": "456673345673436xxx",
                     "IMSI": [
                         {
-                            "@id": "kb:mobile-account2-05328472-66de-4290-8c95-0984504e7279"
+                            "@id": "kb:mobile-account-05328472-66de-4290-8c95-0984504e7279"
                         }
                     ],
                     "uco-observable:SIMType": "USIM",
@@ -102,19 +102,19 @@
             "uco-core:name": "Vodafone"
         },
         {
-            "@id": "kb:device-account-relationship1-25eeee57-4d61-49ba-95bf-919277cf9749",
+            "@id": "kb:device-account-relationship-25eeee57-4d61-49ba-95bf-919277cf9749",
             "@type": "uco-core:Relationship",
             "uco-core:source": {
                 "@id": "kb:mobile-device-d5143a67-8b61-491b-a5e9-863b606e296a"
             },
             "uco-core:target": {
-                "@id": "kb:mobile-account1-09da8ec2-8d6c-41e3-8bd9-bfd06a550141"
+                "@id": "kb:mobile-account-09da8ec2-8d6c-41e3-8bd9-bfd06a550141"
             },
             "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:mobile-account1-09da8ec2-8d6c-41e3-8bd9-bfd06a550141",
+            "@id": "kb:mobile-account-09da8ec2-8d6c-41e3-8bd9-bfd06a550141",
             "@type": "uco-observable:MobileAccount",
             "uco-core:hasFacet": [
                 {
@@ -132,7 +132,7 @@
             ]
         },
         {
-            "@id": "kb:mobile-account2-05328472-66de-4290-8c95-0984504e7279",
+            "@id": "kb:mobile-account-05328472-66de-4290-8c95-0984504e7279",
             "@type": "uco-observable:MobileAccount",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/mobile_device_and_sim_card/mobile_device_and_sim_card.json
+++ b/examples/illustrations/mobile_device_and_sim_card/mobile_device_and_sim_card.json
@@ -13,7 +13,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:mobile-device-uuid",
+            "@id": "kb:mobile-device-d5143a67-8b61-491b-a5e9-863b606e296a",
             "@type": "uco-observable:MobileDevice",
             "uco-core:hasFacet": [
                 {
@@ -63,21 +63,21 @@
             "uco-core:name": "Apple"
         },
         {
-            "@id": "kb:trace-relationship1-uuid",
+            "@id": "kb:trace-relationship1-44bc4b9d-680d-499f-9db1-80af07e11bdc",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:sim-card-uuid"
+                "@id": "kb:sim-card-8b2024b5-1e73-405c-b89f-6e4be86692ef"
             },
             "uco-core:target": [
                 {
-                    "@id": "kb:mobile-device-uuid"
+                    "@id": "kb:mobile-device-d5143a67-8b61-491b-a5e9-863b606e296a"
                 }
             ],
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:sim-card-uuid",
+            "@id": "kb:sim-card-8b2024b5-1e73-405c-b89f-6e4be86692ef",
             "@type": "uco-observable:SIMCard",
             "uco-core:hasFacet": [
                 {
@@ -85,7 +85,7 @@
                     "uco-observable:ICCID": "456673345673436xxx",
                     "IMSI": [
                         {
-                            "@id": "kb:mobile-account2-uuid"
+                            "@id": "kb:mobile-account2-05328472-66de-4290-8c95-0984504e7279"
                         }
                     ],
                     "uco-observable:SIMType": "USIM",
@@ -102,19 +102,19 @@
             "uco-core:name": "Vodafone"
         },
         {
-            "@id": "kb:device-account-relationship1",
+            "@id": "kb:device-account-relationship1-25eeee57-4d61-49ba-95bf-919277cf9749",
             "@type": "uco-core:Relationship",
             "uco-core:source": {
-                "@id": "kb:mobile-device-uuid"
+                "@id": "kb:mobile-device-d5143a67-8b61-491b-a5e9-863b606e296a"
             },
             "uco-core:target": {
-                "@id": "kb:mobile-account1-uuid"
+                "@id": "kb:mobile-account1-09da8ec2-8d6c-41e3-8bd9-bfd06a550141"
             },
             "uco-core:kindOfRelationship": "Has_Account",
             "uco-core:isDirectional": true
         },
         {
-            "@id": "kb:mobile-account1-uuid",
+            "@id": "kb:mobile-account1-09da8ec2-8d6c-41e3-8bd9-bfd06a550141",
             "@type": "uco-observable:MobileAccount",
             "uco-core:hasFacet": [
                 {
@@ -132,7 +132,7 @@
             ]
         },
         {
-            "@id": "kb:mobile-account2-uuid",
+            "@id": "kb:mobile-account2-05328472-66de-4290-8c95-0984504e7279",
             "@type": "uco-observable:MobileAccount",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/raw_data/raw_data.json
+++ b/examples/illustrations/raw_data/raw_data.json
@@ -11,7 +11,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:digital_photograph_thumbnail1-a4e05bbf-f533-43a5-abaf-e8907afdc7a0",
+            "@id": "kb:digital_photograph_thumbnail-a4e05bbf-f533-43a5-abaf-e8907afdc7a0",
             "rdfs:seeAlso": {
                 "@id": "https://unifiedcyberontology.atlassian.net/browse/OC-222"
             },
@@ -43,13 +43,13 @@
             ]
         },
         {
-            "@id": "kb:relationship0-e463912d-2ebb-4558-9990-3391eef56c4d",
+            "@id": "kb:relationship-e463912d-2ebb-4558-9990-3391eef56c4d",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:digital_photograph_thumbnail1-a4e05bbf-f533-43a5-abaf-e8907afdc7a0"
+                "@id": "kb:digital_photograph_thumbnail-a4e05bbf-f533-43a5-abaf-e8907afdc7a0"
             },
             "uco-core:target": {
-                "@id": "kb:digital_photograph1-fb36765f-2bd6-4763-9a3a-be32731162ce"
+                "@id": "kb:digital_photograph-fb36765f-2bd6-4763-9a3a-be32731162ce"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -62,7 +62,7 @@
             ]
         },
         {
-            "@id": "kb:digital_photograph1-fb36765f-2bd6-4763-9a3a-be32731162ce",
+            "@id": "kb:digital_photograph-fb36765f-2bd6-4763-9a3a-be32731162ce",
             "@type": "uco-observable:RasterPicture",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/raw_data/raw_data.json
+++ b/examples/illustrations/raw_data/raw_data.json
@@ -11,7 +11,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:digital_photograph_thumbnail1",
+            "@id": "kb:digital_photograph_thumbnail1-a4e05bbf-f533-43a5-abaf-e8907afdc7a0",
             "rdfs:seeAlso": {
                 "@id": "https://unifiedcyberontology.atlassian.net/browse/OC-222"
             },
@@ -43,13 +43,13 @@
             ]
         },
         {
-            "@id": "kb:relationship0",
+            "@id": "kb:relationship0-e463912d-2ebb-4558-9990-3391eef56c4d",
             "@type": "uco-observable:ObservableRelationship",
             "uco-core:source": {
-                "@id": "kb:digital_photograph_thumbnail1"
+                "@id": "kb:digital_photograph_thumbnail1-a4e05bbf-f533-43a5-abaf-e8907afdc7a0"
             },
             "uco-core:target": {
-                "@id": "kb:digital_photograph1"
+                "@id": "kb:digital_photograph1-fb36765f-2bd6-4763-9a3a-be32731162ce"
             },
             "uco-core:kindOfRelationship": "Contained_Within",
             "uco-core:isDirectional": true,
@@ -62,7 +62,7 @@
             ]
         },
         {
-            "@id": "kb:digital_photograph1",
+            "@id": "kb:digital_photograph1-fb36765f-2bd6-4763-9a3a-be32731162ce",
             "@type": "uco-observable:RasterPicture",
             "uco-core:hasFacet": [
                 {

--- a/examples/illustrations/recoverability/README.md
+++ b/examples/illustrations/recoverability/README.md
@@ -34,7 +34,7 @@ Using the NIST image `dfr-01-fat.dd` of a FAT 12 file system with unallocated fi
 ```json
 [
     {
-        "@id": "kb:CB0354F5-2DBD-4C02-8A6C-011B77125EE2",
+        "@id": "kb:cb0354f5-2dbd-4c02-8a6c-011b77125ee2",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:File"
@@ -90,7 +90,7 @@ This recovered file system entry can be represented using the `observable:Recove
 ```json
 [
     {
-        "@id": "kb:BD64BDD9-3DCD-4828-A25B-A72C06E472CD",
+        "@id": "kb:bd64bdd9-3dcd-4828-a25b-a72c06e472cd",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:File"
@@ -132,7 +132,7 @@ Again using the [Crossover](https://caseontology.org/examples/crossover/) shared
 ```json
 [
     {
-        "@id": "kb:665D63BE-93E6-4D3E-8E75-3112BE091E93",
+        "@id": "kb:665d63be-93e6-4d3e-8e75-3112be091e93",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:File"
@@ -183,7 +183,7 @@ Similar to a LNK file on Windows, entries in the external.db entry on the Samsun
 ```json
 [
     {
-        "@id": "kb:4026FABD-924D-4138-A6BA-73DF2EB37BCB",
+        "@id": "kb:4026fabd-924d-4138-a6ba-73df2eb37bcb",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:File"
@@ -233,7 +233,7 @@ This recovered chat message can be represented using the `observable:RecoveredOb
 ```json
 [
     {
-        "@id": "kb:C01E67F9-ADB5-48BD-B09D-E7326FA8D592",
+        "@id": "kb:c01e67f9-adb5-48bd-b09d-e7326fa8d592",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:Message"

--- a/examples/illustrations/recoverability/recoverability.json
+++ b/examples/illustrations/recoverability/recoverability.json
@@ -8,7 +8,7 @@
     },
     "@graph": [
         {
-            "@id": "kb:4026FABD-924D-4138-A6BA-73DF2EB37BCB",
+            "@id": "kb:4026fabd-924d-4138-a6ba-73df2eb37bcb",
             "@type": [
                 "drafting:RecoveredObject",
                 "uco-observable:File"
@@ -44,7 +44,7 @@
             ]
         },
         {
-            "@id": "kb:665D63BE-93E6-4D3E-8E75-3112BE091E93",
+            "@id": "kb:665d63be-93e6-4d3e-8e75-3112be091e93",
             "@type": [
                 "drafting:RecoveredObject",
                 "uco-observable:File"
@@ -88,7 +88,7 @@
             ]
         },
         {
-            "@id": "kb:BD64BDD9-3DCD-4828-A25B-A72C06E472CD",
+            "@id": "kb:bd64bdd9-3dcd-4828-a25b-a72c06e472cd",
             "@type": [
                 "drafting:RecoveredObject",
                 "uco-observable:File"
@@ -123,7 +123,7 @@
             ]
         },
         {
-            "@id": "kb:C01E67F9-ADB5-48BD-B09D-E7326FA8D592",
+            "@id": "kb:c01e67f9-adb5-48bd-b09d-e7326fa8d592",
             "@type": [
                 "drafting:RecoveredObject",
                 "uco-observable:Message"
@@ -163,7 +163,7 @@
             ]
         },
         {
-            "@id": "kb:CB0354F5-2DBD-4C02-8A6C-011B77125EE2",
+            "@id": "kb:cb0354f5-2dbd-4c02-8a6c-011b77125ee2",
             "@type": [
                 "drafting:RecoveredObject",
                 "uco-observable:File"

--- a/examples/illustrations/recoverability/src/recoverability-badquinn_ost_tmp.json
+++ b/examples/illustrations/recoverability/src/recoverability-badquinn_ost_tmp.json
@@ -1,6 +1,6 @@
 [
     {
-        "@id": "kb:BD64BDD9-3DCD-4828-A25B-A72C06E472CD",
+        "@id": "kb:bd64bdd9-3dcd-4828-a25b-a72c06e472cd",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:File"

--- a/examples/illustrations/recoverability/src/recoverability-crossover_thebatplan_lnk.json
+++ b/examples/illustrations/recoverability/src/recoverability-crossover_thebatplan_lnk.json
@@ -1,6 +1,6 @@
 [
     {
-        "@id": "kb:665D63BE-93E6-4D3E-8E75-3112BE091E93",
+        "@id": "kb:665d63be-93e6-4d3e-8e75-3112be091e93",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:File"

--- a/examples/illustrations/recoverability/src/recoverability-diana_sent_location.json
+++ b/examples/illustrations/recoverability/src/recoverability-diana_sent_location.json
@@ -1,6 +1,6 @@
 [
     {
-        "@id": "kb:C01E67F9-ADB5-48BD-B09D-E7326FA8D592",
+        "@id": "kb:c01e67f9-adb5-48bd-b09d-e7326fa8d592",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:Message"

--- a/examples/illustrations/recoverability/src/recoverability-nist_dfr_01_fat_xbied.json
+++ b/examples/illustrations/recoverability/src/recoverability-nist_dfr_01_fat_xbied.json
@@ -1,6 +1,6 @@
 [
     {
-        "@id": "kb:CB0354F5-2DBD-4C02-8A6C-011B77125EE2",
+        "@id": "kb:cb0354f5-2dbd-4c02-8a6c-011b77125ee2",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:File"

--- a/examples/illustrations/recoverability/src/recoverability-sqlite_whatsapp.json
+++ b/examples/illustrations/recoverability/src/recoverability-sqlite_whatsapp.json
@@ -1,6 +1,6 @@
 [
     {
-        "@id": "kb:4026FABD-924D-4138-A6BA-73DF2EB37BCB",
+        "@id": "kb:4026fabd-924d-4138-a6ba-73df2eb37bcb",
         "@type": [
             "drafting:RecoveredObject",
             "uco-observable:File"


### PR DESCRIPTION
This pull request to update the following CASE examples in order that they are all lowercase and have a valid 16-byte UUID.

The eleven (11) examples affected by this change are:

- account.json (29 changes);
- bulk_extractor_forensic_path.json (25 changes);
- call_log.json (27 changes);
- cell_site.json (5 changes);
- database_records.json (no changes)
- device.json (2 changes);
- exif_data.json (23 changes);
- location.json (2 changes);
- mobile_device_and_sim_card.json (11 changes)
- raw_data.json (5 changes)
- recoverability.json (5 changes)

*_The remaining 9 examples will be checked and uploaded on the next working day._

The above files were processed, and then manually fully checked against their log file,
Unfortunately, the zip file containing the logs fails to uploaded into this pull request, but is available on request, and will be retried adding to this pull request using a different version of chrome later today.

The following addition notes below indicate details which were incorrectly reported within the logs;

- account.json
 1. Two (2) independent relationship objects defined with the same Iri "account4", the 2nd definition was manually renamed "account5-{uuid}".

- bulk_extractor_forensic_path.json
 1. The definition for "kb:disk_image" (on line 283) contains an @type array of 2 elements ["uco-observable:File", "uco-observable:Image"] which results in the log incorrectly thinking that it is a reference and not a definition.
This was manually checked.

- cell_site.json
 1. The definitions for "kb:observation-009101f6-ba93-4a3d-acb0-455102b5b1e1" (on line 238) and "kb:observation-21841f2a-6c14-48d7-b9d3-f081d43bc19b" (on line 256) both contain an @type array of 2 elements ["uco-core:UcoObject", "sosa:Observation"] which results in the log incorrectly thinking that it is a reference and not a definition.
   This was manually checked.

 2. All the original @id's contain valid Iri's except the definition for "urn:example:cell-site-kb:cell-cite-204-16-1014-13399"" (on line 292). This is defined within the example, and should therefore ideally follow the required Iri naming convention, it has therefore been manually given the following Iri:
    "kb:cell-cite-204-16-1014-13399-cc0e0667-eadf-4b2e-9618-3f62b1bdae26"
   and the associated references on lines 127, 244, 262 and 285 have been manually updated to reflect this change

- device.json
1. The definition for "kb:forensic_lab1-uuid" was updated but isn't defined within the example, but it is referenced on line 28 for the object defined on line 25.
This was manually checked.

- raw_data.json
1. The definition for "kb:digital_photograph_thumbnail1-{uuid}" (on line 14) contains an @type array of 2 elements ["uco-observable:ContentData", "uco-observable:RasterPicture"] which results in the log incorrectly thinking that it is a reference and not a definition.
   This was manually checked.

- recoverability.json
1. The four (4) definitions for "kb:4026fabd-924d-4138-a6ba-73df2eb37bcb" (line 11), "kb:665d63be-93e6-4d3e-8e75-3112be091e93" (line 47), "kb:bd64bdd9-3dcd-4828-a25b-a72c06e472cd" (line 91) and "kb:cb0354f5-2dbd-4c02-8a6c-011b77125ee2" (line 166) all contain an @type array of 2 elements ["drafting:RecoveredObject", "uco-observable:File"] which results in the log incorrectly thinking that it is a reference and not a definition.
   This was manually checked.

2. The definition for "kb:c01e67f9-adb5-48bd-b09d-e7326fa8d592" (line 126) contains an @type array of 2 elements ["drafting:RecoveredObject", "uco-observable:Message"] which results in the log incorrectly thinking that it is a reference and not a definition.
   This was manually checked.


# Coordination

@ajnelson-nist additionally reviewed:

- [x] Numeric identifiers removed from IRI *fragment* prefixes (this moves examples towards "real-world" data where it can't be known that e.g. `kb:account-${uuid}` would be appropriately named `kb:account1-${uuid}`.
- [x] All Make-managed resources regenerate consistently with new changes (verified by running `make check`)
- [x] `README.md`s containing node references also receive IRI updates