### PR TITLE
Add supply-chain review target

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "dependencies/CASE-develop"]
 	path = dependencies/CASE-develop
 	url = https://github.com/casework/CASE.git
+	branch = develop
 [submodule "dependencies/CASE-develop-2.0.0"]
 	path = dependencies/CASE-develop-2.0.0
 	url = https://github.com/casework/CASE.git
+	branch = develop-2.0.0
 [submodule "dependencies/CASE-unstable"]
 	path = dependencies/CASE-unstable
 	url = https://github.com/casework/CASE-Archive.git
+	branch = unstable
 [submodule "dependencies/CASE-unstable-2.0.0"]
 	path = dependencies/CASE-unstable-2.0.0
 	url = https://github.com/casework/CASE-Archive.git
+	branch = unstable-2.0.0

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ all: \
 	  --directory examples/illustrations
 
 .PHONY: \
+  check-supply-chain \
+  check-supply-chain-pre-commit \
+  check-supply-chain-submodules \
   download
 
 .dependencies.done.log: \
@@ -115,6 +118,28 @@ check: \
 	$(MAKE) \
 	  --directory examples/illustrations \
 	  check
+
+# This target's dependencies potentially modify the working directory's Git state, so it is intentionally not a dependency of check.
+check-supply-chain: \
+  check-supply-chain-pre-commit \
+  check-supply-chain-submodules
+
+check-supply-chain-pre-commit: \
+  .venv-pre-commit/var/.pre-commit-built.log
+	source .venv-pre-commit/bin/activate \
+	  && pre-commit autoupdate
+	git diff \
+	  --exit-code \
+	  .pre-commit-config.yaml
+
+check-supply-chain-submodules: \
+  .git_submodule_init.done.log
+	git submodule update \
+	  --remote
+	git diff \
+	  --exit-code \
+	  --ignore-submodules=dirty \
+	  dependencies
 
 clean:
 	@$(MAKE) \


### PR DESCRIPTION
This patch adds the ability to run a single command to handle checking all direct-dependencies within `pre-commit` and Git submodules.

While some other CASE repositories run this command nightly, this patch leaves that as a future decision due to current testing procedures within the CASE and UCO ontology repositories.