### PR TITLE
Separate drafting-ontology validation from example validation

### DIFF
--- a/examples/illustrations/.gitignore
+++ b/examples/illustrations/.gitignore
@@ -1,3 +1,4 @@
+.drafting.ttl.validates*.log
 all-drafting.ttl
 generated-*.md
 generated-*.sed

--- a/examples/illustrations/src/illustration-nosrc.mk
+++ b/examples/illustrations/src/illustration-nosrc.mk
@@ -30,9 +30,19 @@ example_name := $(shell basename $$PWD)
 # Use a drafting.ttl file in the validation and dependency list, if it is present.
 drafting_ttl := $(wildcard drafting.ttl)
 ifeq ($(drafting_ttl),)
+drafting_dependency :=
+drafting_dependency_develop :=
+drafting_dependency_develop_2_0_0 :=
+drafting_dependency_unstable :=
+drafting_dependency_unstable_2_0_0 :=
 drafting_validation_flag :=
 else
-drafting_validation_flag := --ontology-graph $(wildcard drafting.ttl) --review-tbox
+drafting_dependency := .drafting.ttl.validates.log
+drafting_dependency_develop := .drafting.ttl.validates-develop.log
+drafting_dependency_develop_2_0_0 := .drafting.ttl.validates-develop-2.0.0.log
+drafting_dependency_unstable := .drafting.ttl.validates-unstable.log
+drafting_dependency_unstable_2_0_0 := .drafting.ttl.validates-unstable-2.0.0.log
+drafting_validation_flag := --ontology-graph $(drafting_ttl)
 endif
 
 RENDER_PROV ?=
@@ -114,7 +124,7 @@ $(example_name)-prov.ttl: \
 $(example_name)_validation.ttl: \
   $(example_name).json \
   $(RDF_TOOLKIT_JAR) \
-  $(drafting_ttl) \
+  $(drafting_dependency) \
   $(top_srcdir)/.venv.done.log
 	rm -f __$@
 	source $(top_srcdir)/venv/bin/activate \
@@ -138,7 +148,7 @@ $(example_name)_validation.ttl: \
 $(example_name)_validation-develop.ttl: \
   $(example_name).json \
   $(RDF_TOOLKIT_JAR) \
-  $(drafting_ttl) \
+  $(drafting_dependency_develop) \
   $(top_srcdir)/.venv.done.log \
   $(top_srcdir)/dependencies/CASE-develop.ttl
 	rm -f __$@
@@ -165,7 +175,7 @@ $(example_name)_validation-develop.ttl: \
 $(example_name)_validation-develop-2.0.0.ttl: \
   $(example_name).json \
   $(RDF_TOOLKIT_JAR) \
-  $(drafting_ttl) \
+  $(drafting_dependency_develop_2_0_0) \
   $(top_srcdir)/.venv.done.log \
   $(top_srcdir)/dependencies/CASE-develop-2.0.0.ttl
 	rm -f __$@
@@ -192,7 +202,7 @@ $(example_name)_validation-develop-2.0.0.ttl: \
 $(example_name)_validation-unstable.ttl: \
   $(example_name).json \
   $(RDF_TOOLKIT_JAR) \
-  $(drafting_ttl) \
+  $(drafting_dependency_unstable) \
   $(top_srcdir)/.venv.done.log \
   $(top_srcdir)/dependencies/CASE-unstable.ttl
 	rm -f __$@
@@ -219,7 +229,7 @@ $(example_name)_validation-unstable.ttl: \
 $(example_name)_validation-unstable-2.0.0.ttl: \
   $(example_name).json \
   $(RDF_TOOLKIT_JAR) \
-  $(drafting_ttl) \
+  $(drafting_dependency_unstable_2_0_0) \
   $(top_srcdir)/.venv.done.log \
   $(top_srcdir)/dependencies/CASE-unstable-2.0.0.ttl
 	rm -f __$@
@@ -243,6 +253,78 @@ $(example_name)_validation-unstable-2.0.0.ttl: \
 	rm __$@
 	mv _$@ $@
 
+.drafting.ttl.validates.log: \
+  $(drafting_ttl) \
+  $(top_srcdir)/.venv.done.log
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --allow-infos \
+	    --metashacl \
+	    --ontology-graph $(drafting_ttl) \
+	    --review-tbox \
+	    $(drafting_ttl)
+	touch $@
+
+.drafting.ttl.validates-develop.log: \
+  $(drafting_ttl) \
+  $(top_srcdir)/.venv.done.log \
+  $(top_srcdir)/dependencies/CASE-develop.ttl
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --allow-infos \
+	    --built-version none \
+	    --metashacl \
+	    --ontology-graph $(drafting_ttl) \
+	    --ontology-graph $(top_srcdir)/dependencies/CASE-develop.ttl \
+	    --review-tbox \
+	    $(drafting_ttl)
+	touch $@
+
+.drafting.ttl.validates-develop-2.0.0.log: \
+  $(drafting_ttl) \
+  $(top_srcdir)/.venv.done.log \
+  $(top_srcdir)/dependencies/CASE-develop-2.0.0.ttl
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --allow-infos \
+	    --built-version none \
+	    --metashacl \
+	    --ontology-graph $(drafting_ttl) \
+	    --ontology-graph $(top_srcdir)/dependencies/CASE-develop-2.0.0.ttl \
+	    --review-tbox \
+	    $(drafting_ttl)
+	touch $@
+
+.drafting.ttl.validates-unstable.log: \
+  $(drafting_ttl) \
+  $(top_srcdir)/.venv.done.log \
+  $(top_srcdir)/dependencies/CASE-unstable.ttl
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --allow-infos \
+	    --built-version none \
+	    --metashacl \
+	    --ontology-graph $(drafting_ttl) \
+	    --ontology-graph $(top_srcdir)/dependencies/CASE-unstable.ttl \
+	    --review-tbox \
+	    $(drafting_ttl)
+	touch $@
+
+.drafting.ttl.validates-unstable-2.0.0.log: \
+  $(drafting_ttl) \
+  $(top_srcdir)/.venv.done.log \
+  $(top_srcdir)/dependencies/CASE-unstable-2.0.0.ttl
+	source $(top_srcdir)/venv/bin/activate \
+	  && case_validate \
+	    --allow-infos \
+	    --built-version none \
+	    --metashacl \
+	    --ontology-graph $(drafting_ttl) \
+	    --ontology-graph $(top_srcdir)/dependencies/CASE-unstable-2.0.0.ttl \
+	    --review-tbox \
+	    $(drafting_ttl)
+	touch $@
+
 check: \
   check-pytest \
   $(example_name)_validation.ttl \
@@ -264,6 +346,7 @@ check-pytest: \
 
 clean:
 	@rm -f \
+	  .drafting.ttl.*.log \
 	  figures/*.dot \
 	  figures/*.svg \
 	  $(example_name)_validation*.ttl


### PR DESCRIPTION
This patch adds flag files to decrease iteration time when checking example data.  A review from scratch will run slightly longer, but edits to instance data will no longer re-check `drafting.ttl`.

This patch also adds `--metashacl` to run SHACL-SHACL validation against the mix of `drafting.ttl` and each selected build of CASE.